### PR TITLE
Add test case for silent flag

### DIFF
--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -68,7 +68,7 @@ class RollbarSourceMapPlugin {
     const req = request.post(ROLLBAR_ENDPOINT, (err, res, body) => {
       if (!err && res.statusCode === 200) {
         if (!this.silent) {
-          console.info(`\nUploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
+          console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
         }
         return cb();
       }

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -257,12 +257,12 @@ describe('RollbarSourceMapPlugin', function() {
         if (err) {
           return done(err);
         }
-        expect(this.info).toHaveBeenCalledWith('\nUploaded vendor.5190.js.map to Rollbar');
+        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
         done();
       });
     });
 
-    it('should not log upload if silent option is true', function(done) {
+    it('should not log upload to console if silent option is true', function(done) {
       const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
         .post('/api/1/sourcemap')
         .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
@@ -274,6 +274,22 @@ describe('RollbarSourceMapPlugin', function() {
           return done(err);
         }
         expect(this.info).toNotHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should log upload to console if silent option is false', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+      const { compilation, chunk } = this;
+      this.plugin.silent = false;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        if (err) {
+          return done(err);
+        }
+        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
         done();
       });
     });


### PR DESCRIPTION
Test that console.info is called when false is used for silent flag.

Also removes a leading `\n` from the output.