### PR TITLE
Uprade devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "eslint-config-airbnb-base": "^3.0.1",
     "eslint-plugin-import": "^1.8.0",
     "expect": "^1.20.1",
-    "mocha": "^2.4.5",
+    "mocha": "^3.0.2",
     "nock": "^8.0.0",
-    "nyc": "^7.0.0",
+    "nyc": "^8.3.0",
     "rimraf": "^2.5.2",
     "watch": "^0.19.1"
   },


### PR DESCRIPTION
Upgrade to latest mocha, nyc. Purposely not upgrading eslint, eslint-config-airbnb-base because it doesn't work in Node 0.12.