### PR TITLE
Upload unnamed chunks when includeChunks is not specified

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,7 @@
     "comma-dangle": 0,
     "consistent-return": 0,
     "func-names": 0,
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
     "prefer-arrow-callback": 0,
     "space-before-function-paren": 0
   },

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Allowed values are as follows:
 - `includeChunks`: *(optional)* An array of chunks for which sourcemaps should be uploaded.
   This should correspond to the names in the webpack config `entry` field.
   If there's only one chunk, it can be a string rather than an array. If not supplied,
-  all sourcemaps emitted by webpack will be uploaded.
+  all sourcemaps emitted by webpack will be uploaded, including those for unnamed chunks.
 - `silent`: *(optional)* `true | false` If `false`, success messages will be logged to the console for each upload.
    Defaults to `false`.
 

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -43,15 +43,16 @@ class RollbarSourceMapPlugin {
 
   getAssets(compilation) {
     const { includeChunks } = this;
-    const { assetsByChunkName } = compilation.getStats().toJson();
+    const { chunks } = compilation.getStats().toJson();
 
-    return reduce(assetsByChunkName, (result, assets, chunkName) => {
+    return reduce(chunks, (result, chunk) => {
+      const chunkName = chunk.names[0];
       if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
         return result;
       }
 
-      const sourceFile = find(assets, asset => /\.js$/.test(asset));
-      const sourceMap = find(assets, asset => /\.js\.map$/.test(asset));
+      const sourceFile = find(chunk.files, file => /\.js$/.test(file));
+      const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
 
       if (!sourceFile || !sourceMap) {
         return result;


### PR DESCRIPTION
As reported in https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/27 sourcemaps for unnamed chunks such as those resulting from `require.ensure` or `System.import` were not being uploaded. The docs claimed that all sourcemaps would be uploaded if `includeChunks` was not specfied. 

Previously the plugin looked at `assetsByChunkname` from the webpack stats but that object does not contain unnamed chunks. This fixes by changing to use the `chunks` field.

fixes #27