### PR TITLE
Add showWarnings option to avoid logging when not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Allowed values are as follows:
   all sourcemaps emitted by webpack will be uploaded, including those for unnamed chunks.
 - `silent`: *(optional)* `true | false` If `false`, success messages will be logged to the console for each upload.
    Defaults to `false`.
+- `showWarnings`: *(optional)* `true | false` If `true`, all warning messages will be logged to the console for each upload.
+   Defaults to `true`.
 
 App Configuration
 --------------------

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -12,13 +12,15 @@ class RollbarSourceMapPlugin {
     version,
     publicPath,
     includeChunks = [],
-    silent = false
+    silent = false,
+    showWarnings = true
   }) {
     this.accessToken = accessToken;
     this.version = version;
     this.publicPath = publicPath;
     this.includeChunks = [].concat(includeChunks);
     this.silent = silent;
+    this.showWarnings = showWarnings;
   }
 
   afterEmit(compilation, cb) {
@@ -30,8 +32,8 @@ class RollbarSourceMapPlugin {
     }
 
     this.uploadSourceMaps(compilation, (err) => {
-      if (err) {
-        compilation.errors.push(...handleError(err));
+      if (err && this.showWarnings) {
+        compilation.warnings.push(...handleError(err));
       }
       cb();
     });

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -100,16 +100,30 @@ describe('RollbarSourceMapPlugin', function() {
       });
     });
 
-    it('should add upload errors to compilation', function(done) {
+    it('should add upload warnings to compilation', function(done) {
       const compilation = {
-        errors: []
+        warnings: []
       };
       this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
         .andCall((comp, callback) => callback(new Error()));
       this.plugin.afterEmit(compilation, () => {
         expect(this.uploadSourceMaps.calls.length).toBe(1);
-        expect(compilation.errors.length).toBe(1);
-        expect(compilation.errors[0]).toBeA(Error);
+        expect(compilation.warnings.length).toBe(1);
+        expect(compilation.warnings[0]).toBeA(Error);
+        done();
+      });
+    });
+
+    it('should not add upload warnings to compilation if showWarnings is false', function(done) {
+      const compilation = {
+        warnings: []
+      };
+      this.plugin.showWarnings = false;
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
+        .andCall((comp, callback) => callback(new Error()));
+      this.plugin.afterEmit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(1);
+        expect(compilation.warnings.length).toBe(0);
         done();
       });
     });


### PR DESCRIPTION
We are having a problem in our CI process where we find ourselves having failing builds due to a connection problem with Rollbar's API. This causes Node to exit with a process status of 2, which waterfalls into our build to fail completely just because it couldn't upload the sourcemap to Rollbar.

We want to have control over that, so I added an `ignoreErrors` option to avoid pushing errors to Webpack and therefore, stop having Node exiting with an undesired status.

Small copy/paste from the error this PR talks about: `failed to upload bundle.b7a66707eb974eb316fb.js.map to Rollbar: getaddrinfo ENOTFOUND api.rollbar.com`