### PR TITLE
add a `transform` option for updating 'sourceFile' and 'sourceMap'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ const webpackConfig = {
   plugins: [new RollbarSourceMapPlugin({
     accessToken: 'aaaabbbbccccddddeeeeffff00001111',
     version: 'version_string_here',
-    publicPath: PUBLIC_PATH
+    publicPath: PUBLIC_PATH,
+    transform: function (sourceFile, sourceMap, sourceContent) {
+      return {sourceFile, sourceMap}
+    }
   })]
 }
 ```

--- a/dist/RollbarSourceMapPlugin.js
+++ b/dist/RollbarSourceMapPlugin.js
@@ -1,0 +1,191 @@
+'use strict';
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _async = require('async');
+
+var _async2 = _interopRequireDefault(_async);
+
+var _request = require('request');
+
+var _request2 = _interopRequireDefault(_request);
+
+var _verror = require('verror');
+
+var _verror2 = _interopRequireDefault(_verror);
+
+var _lodash = require('lodash.find');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _lodash3 = require('lodash.reduce');
+
+var _lodash4 = _interopRequireDefault(_lodash3);
+
+var _helpers = require('./helpers');
+
+var _constants = require('./constants');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var RollbarSourceMapPlugin = function () {
+  function RollbarSourceMapPlugin(_ref) {
+    var accessToken = _ref.accessToken,
+        version = _ref.version,
+        publicPath = _ref.publicPath,
+        transform = _ref.transform,
+        _ref$includeChunks = _ref.includeChunks,
+        includeChunks = _ref$includeChunks === undefined ? [] : _ref$includeChunks,
+        _ref$silent = _ref.silent,
+        silent = _ref$silent === undefined ? false : _ref$silent,
+        _ref$ignoreErrors = _ref.ignoreErrors,
+        ignoreErrors = _ref$ignoreErrors === undefined ? false : _ref$ignoreErrors;
+    (0, _classCallCheck3.default)(this, RollbarSourceMapPlugin);
+
+    this.accessToken = accessToken;
+    this.version = version;
+    this.publicPath = publicPath;
+    this.transform = transform;
+    this.includeChunks = [].concat(includeChunks);
+    this.silent = silent;
+    this.ignoreErrors = ignoreErrors;
+  }
+
+  (0, _createClass3.default)(RollbarSourceMapPlugin, [{
+    key: 'afterEmit',
+    value: function afterEmit(compilation, cb) {
+      var _this = this;
+
+      var errors = (0, _helpers.validateOptions)(this);
+
+      if (errors) {
+        var _compilation$errors;
+
+        (_compilation$errors = compilation.errors).push.apply(_compilation$errors, (0, _toConsumableArray3.default)((0, _helpers.handleError)(errors)));
+        return cb();
+      }
+
+      this.uploadSourceMaps(compilation, function (err) {
+        if (err) {
+          if (!_this.ignoreErrors) {
+            var _compilation$errors2;
+
+            (_compilation$errors2 = compilation.errors).push.apply(_compilation$errors2, (0, _toConsumableArray3.default)((0, _helpers.handleError)(err)));
+          } else if (!_this.silent) {
+            var _compilation$warnings;
+
+            (_compilation$warnings = compilation.warnings).push.apply(_compilation$warnings, (0, _toConsumableArray3.default)((0, _helpers.handleError)(err)));
+          }
+        }
+        cb();
+      });
+    }
+  }, {
+    key: 'apply',
+    value: function apply(compiler) {
+      compiler.plugin('after-emit', this.afterEmit.bind(this));
+    }
+  }, {
+    key: 'getAssets',
+    value: function getAssets(compilation) {
+      var includeChunks = this.includeChunks;
+
+      var _compilation$getStats = compilation.getStats().toJson(),
+          chunks = _compilation$getStats.chunks;
+
+      return (0, _lodash4.default)(chunks, function (result, chunk) {
+        var chunkName = chunk.names[0];
+        if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
+          return result;
+        }
+
+        var sourceFile = (0, _lodash2.default)(chunk.files, function (file) {
+          return (/\.js$/.test(file)
+          );
+        });
+        var sourceMap = (0, _lodash2.default)(chunk.files, function (file) {
+          return (/\.js\.map$/.test(file)
+          );
+        });
+
+        if (!sourceFile || !sourceMap) {
+          return result;
+        }
+
+        return [].concat((0, _toConsumableArray3.default)(result), [{ sourceFile: sourceFile, sourceMap: sourceMap }]);
+      }, {});
+    }
+  }, {
+    key: 'uploadSourceMap',
+    value: function uploadSourceMap(compilation, _ref2, cb) {
+      var _this2 = this;
+
+      var sourceFile = _ref2.sourceFile,
+          sourceMap = _ref2.sourceMap;
+
+      var req = _request2.default.post(_constants.ROLLBAR_ENDPOINT, function (err, res, body) {
+        if (!err && res.statusCode === 200) {
+          if (!_this2.silent) {
+            console.info('Uploaded ' + sourceMap + ' to Rollbar'); // eslint-disable-line no-console
+          }
+          return cb();
+        }
+
+        var errMessage = 'failed to upload ' + sourceMap + ' to Rollbar';
+        if (err) {
+          return cb(new _verror2.default(err, errMessage));
+        }
+
+        try {
+          var _JSON$parse = JSON.parse(body),
+              message = _JSON$parse.message;
+
+          return cb(new Error(message ? errMessage + ': ' + message : errMessage));
+        } catch (parseErr) {
+          return cb(new _verror2.default(parseErr, errMessage));
+        }
+      });
+
+      // transform sourceFile and sourceMap names
+      var transformResults = void 0;
+      if (this.transform) {
+        transformResults = this.transform(sourceFile, sourceMap, compilation.assets[sourceFile].source());
+      }
+
+      var form = req.form();
+      form.append('access_token', this.accessToken);
+      form.append('version', this.version);
+      form.append('minified_url', this.publicPath + '/' + (transformResults.sourceFile || sourceFile));
+      form.append('source_map', compilation.assets[sourceMap].source(), {
+        filename: transformResults.sourceMap || sourceMap,
+        contentType: 'application/json'
+      });
+    }
+  }, {
+    key: 'uploadSourceMaps',
+    value: function uploadSourceMaps(compilation, cb) {
+      var assets = this.getAssets(compilation);
+      var upload = this.uploadSourceMap.bind(this, compilation);
+
+      _async2.default.each(assets, upload, function (err, results) {
+        if (err) {
+          return cb(err);
+        }
+        return cb(null, results);
+      });
+    }
+  }]);
+  return RollbarSourceMapPlugin;
+}();
+
+module.exports = RollbarSourceMapPlugin;

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,0 +1,8 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var ROLLBAR_ENDPOINT = exports.ROLLBAR_ENDPOINT = 'https://api.rollbar.com/api/1/sourcemap';
+
+var ROLLBAR_REQ_FIELDS = exports.ROLLBAR_REQ_FIELDS = ['accessToken', 'version', 'publicPath'];

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,0 +1,49 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+exports.handleError = handleError;
+exports.validateOptions = validateOptions;
+
+var _verror = require('verror');
+
+var _verror2 = _interopRequireDefault(_verror);
+
+var _constants = require('./constants');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Take a single Error or array of Errors and return an array of errors that
+// have message prefixed.
+function handleError(err) {
+  var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'RollbarSourceMapPlugin';
+
+  if (!err) {
+    return [];
+  }
+
+  var errors = [].concat(err);
+  return errors.map(function (e) {
+    return new _verror2.default(e, prefix);
+  });
+}
+
+// Validate required options and return an array of errors or null if there
+// are no errors.
+function validateOptions(ref) {
+  var errors = _constants.ROLLBAR_REQ_FIELDS.reduce(function (result, field) {
+    if (ref && ref[field]) {
+      return result;
+    }
+
+    return [].concat((0, _toConsumableArray3.default)(result), [new Error('required field, \'' + field + '\', is missing.')]);
+  }, []);
+
+  return errors.length ? errors : null;
+}

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -11,6 +11,7 @@ class RollbarSourceMapPlugin {
     accessToken,
     version,
     publicPath,
+    transform,
     includeChunks = [],
     silent = false,
     ignoreErrors = false
@@ -18,6 +19,7 @@ class RollbarSourceMapPlugin {
     this.accessToken = accessToken;
     this.version = version;
     this.publicPath = publicPath;
+    this.transform = transform;
     this.includeChunks = [].concat(includeChunks);
     this.silent = silent;
     this.ignoreErrors = ignoreErrors;
@@ -92,6 +94,11 @@ class RollbarSourceMapPlugin {
         return cb(new VError(parseErr, errMessage));
       }
     });
+
+    // transform sourceFile and sourceMap names
+    if (this.transform) {
+      {sourceFile, sourceMap} = this.transform(sourceFile, sourceMap, compilation.assets[sourceFile].source());
+    }
 
     const form = req.form();
     form.append('access_token', this.accessToken);

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -96,16 +96,21 @@ class RollbarSourceMapPlugin {
     });
 
     // transform sourceFile and sourceMap names
+    let transformResults;
     if (this.transform) {
-      {sourceFile, sourceMap} = this.transform(sourceFile, sourceMap, compilation.assets[sourceFile].source());
+      transformResults = this.transform(
+        sourceFile,
+        sourceMap,
+        compilation.assets[sourceFile].source()
+      );
     }
 
     const form = req.form();
     form.append('access_token', this.accessToken);
     form.append('version', this.version);
-    form.append('minified_url', `${this.publicPath}/${sourceFile}`);
+    form.append('minified_url', `${this.publicPath}/${transformResults.sourceFile || sourceFile}`);
     form.append('source_map', compilation.assets[sourceMap].source(), {
-      filename: sourceMap,
+      filename: transformResults.sourceMap || sourceMap,
       contentType: 'application/json'
     });
   }


### PR DESCRIPTION
I needed this to include hashes after my sourceFile names but couldn't rename the files themselves.

my workflow:

webpack generates app.js bundle
-> have rollbar match http://cdn.com/js/app-[hash].js instead of http://cdn.com/js/app.js
-> https://hexdocs.pm/phoenix/Mix.Tasks.Phoenix.Digest.html to add hash to app.js based on content and upload it to cdn