### PR TITLE
Add retry policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 node_modules
-dist
 tmp
 *.log
 .nyc_output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,150 +1,54 @@
 # Change Log
 
-## [2.2.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/2.2.0) (2017-06-16)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v2.1.0...2.2.0)
+## [v2.2.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v2.2.0) (2017-06-17)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v2.1.0...v2.2.0)
 
-**Merged pull requests:**
+## [v2.1.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v2.1.0) (2017-05-30)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v2.0.1...v2.1.0)
 
-- Run tests in Node 8 in CI [\#37](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/37) ([brandondoran](https://github.com/brandondoran))
+## [v2.0.1](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v2.0.1) (2017-03-15)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v2.0.0...v2.0.1)
 
-## [v2.1.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v2.1.0) (2017-05-30)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v2.0.1...v2.1.0)
+## [v2.0.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v2.0.0) (2017-03-06)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.7.0...v2.0.0)
 
-**Merged pull requests:**
+## [v1.7.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.7.0) (2017-01-15)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.6.0...v1.7.0)
 
-- Update cross-env to version 5.0.0 🚀 [\#35](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/35) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- Update cross-env to version 4.0.0 🚀 [\#33](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/33) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+## [v1.6.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.6.0) (2017-01-09)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.5.0...v1.6.0)
 
-## [v2.0.1](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v2.0.1) (2017-03-15)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v2.0.0...v2.0.1)
+## [v1.5.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.5.0) (2016-11-22)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.4.0...v1.5.0)
 
-**Merged pull requests:**
+## [v1.4.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.4.0) (2016-10-07)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.3.1...v1.4.0)
 
-- Update codecov to version 2.0.1 🚀 [\#32](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/32) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
+## [v1.3.1](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.3.1) (2016-09-28)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.3.0...v1.3.1)
 
-## [v2.0.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v2.0.0) (2017-03-06)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.7.0...v2.0.0)
+## [v1.3.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.3.0) (2016-09-26)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.2.1...v1.3.0)
 
-**Implemented enhancements:**
+## [v1.2.1](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.2.1) (2016-07-27)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.2.0...v1.2.1)
 
-- Add a simple working example for usage in an Angular app [\#6](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/6)
-- Add showWarnings option to avoid logging when not needed [\#30](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/30) ([nicoecheza](https://github.com/nicoecheza))
+## [v1.2.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.2.0) (2016-05-16)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.1.0...v1.2.0)
 
-**Merged pull requests:**
+## [v1.1.0](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.1.0) (2016-05-12)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.0.4...v1.1.0)
 
-- Add an ignoreErrors option [\#31](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/31) ([brandondoran](https://github.com/brandondoran))
+## [v1.0.4](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.0.4) (2016-05-09)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.0.3...v1.0.4)
 
-## [v1.7.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.7.0) (2017-01-15)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.6.0...v1.7.0)
+## [v1.0.3](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.0.3) (2016-05-07)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.0.2...v1.0.3)
 
-**Fixed bugs:**
+## [v1.0.2](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.0.2) (2016-05-05)
+[Full Changelog](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/compare/v1.0.1...v1.0.2)
 
-- Code splitted sourcemaps not uploaded, despite being emitted by webpack [\#27](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/27)
-- Upload unnamed chunks when includeChunks is not specified [\#28](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/28) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.6.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.6.0) (2017-01-09)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.5.0...v1.6.0)
-
-**Merged pull requests:**
-
-- Upgrade dependencies [\#29](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/29) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.5.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.5.0) (2016-11-22)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.4.0...v1.5.0)
-
-**Closed issues:**
-
-- Remove support for Node 0.12 [\#24](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/24)
-
-**Merged pull requests:**
-
-- Upgrade dependencies to latest [\#26](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/26) ([brandondoran](https://github.com/brandondoran))
-- Upgrade eslint version [\#25](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/25) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.4.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.4.0) (2016-10-07)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.3.1...v1.4.0)
-
-**Merged pull requests:**
-
-- Upgrade watch version [\#23](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/23) ([brandondoran](https://github.com/brandondoran))
-- Upgrade dev deps [\#22](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/22) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.3.1](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.3.1) (2016-09-28)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.3.0...v1.3.1)
-
-**Merged pull requests:**
-
-- Fix a few README typos [\#21](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/21) ([brianr](https://github.com/brianr))
-
-## [v1.3.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.3.0) (2016-09-26)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.2.1...v1.3.0)
-
-**Closed issues:**
-
-- Success messages are only shown if silent: true [\#16](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/16)
-
-**Merged pull requests:**
-
-- Uprade devDependencies [\#19](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/19) ([brandondoran](https://github.com/brandondoran))
-- Add test case for silent flag [\#18](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/18) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.2.1](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.2.1) (2016-07-27)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.2.0...v1.2.1)
-
-**Merged pull requests:**
-
-- Upgrade a number of outdated dependencies [\#17](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/17) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.2.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.2.0) (2016-05-16)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.1.0...v1.2.0)
-
-**Merged pull requests:**
-
-- Transfer to thredup [\#15](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/15) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.1.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.1.0) (2016-05-12)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.0.4...v1.1.0)
-
-**Implemented enhancements:**
-
-- Add a simple working example for usage in a React app [\#5](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/5)
-
-**Merged pull requests:**
-
-- chore\(package\): update eslint-plugin-import to version 1.8.0 [\#14](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/14) ([brandondoran](https://github.com/brandondoran))
-- Add an example for React [\#13](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/13) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.0.4](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.0.4) (2016-05-09)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.0.3...v1.0.4)
-
-**Merged pull requests:**
-
-- chore\(package\): update nyc to version 6.4.4 [\#12](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/12) ([brandondoran](https://github.com/brandondoran))
-- Update eslint-config-airbnb-base to version 3.0.1 🚀 [\#10](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/10) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- Update eslint-config-airbnb-base to version 3.0.0 🚀 [\#9](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/9) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-
-## [v1.0.3](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.0.3) (2016-05-07)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.0.2...v1.0.3)
-
-**Implemented enhancements:**
-
-- Add a change log [\#7](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/7)
-
-**Fixed bugs:**
-
-- publicPath option should be required [\#3](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/3)
-
-**Merged pull requests:**
-
-- Update all dependencies 🌴 [\#8](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/8) ([greenkeeperio-bot](https://github.com/greenkeeperio-bot))
-- Make publicPath required [\#4](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/4) ([brandondoran](https://github.com/brandondoran))
-- Make handleError helper pure [\#2](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/2) ([brandondoran](https://github.com/brandondoran))
-- Disable travis email notifications and limit build to master [\#1](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/pull/1) ([brandondoran](https://github.com/brandondoran))
-
-## [v1.0.2](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.0.2) (2016-05-05)
-[Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.0.1...v1.0.2)
-
-## [v1.0.1](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v1.0.1) (2016-05-05)
+## [v1.0.1](https://github.com/Workable/rollbar-sourcemap-webpack-plugin/tree/v1.0.1) (2016-05-05)
 
 
 \* *This Change Log was automatically generated by [github_changelog_generator](https://github.com/skywinder/Github-Changelog-Generator)*

--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ An array of chunks for which sourcemaps should be uploaded. This should correspo
 #### `silent: boolean` **(default: `false`)**
 If `false`, success and warning messages will be logged to the console for each upload. Note: if you also do not want to see errors, set the `ignoreErrors` option to `true`.
 
+#### `retries: number` **(default: `1`)**
+An integer indicating the number of attempts to get a successful response during the upload process of a single sourcemap.
+
 #### `ignoreErrors: boolean` **(default: `false`)**
 Set to `true` to bypass adding upload errors to the webpack compilation. Do this if you do not want to fail the build when sourcemap uploads fail. If you do not want to fail the build but you do want to see the failures as warnings, make sure `silent` option is set to `false`.
 

--- a/dist/RollbarSourceMapPlugin.js
+++ b/dist/RollbarSourceMapPlugin.js
@@ -1,0 +1,193 @@
+'use strict';
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+var _classCallCheck2 = require('babel-runtime/helpers/classCallCheck');
+
+var _classCallCheck3 = _interopRequireDefault(_classCallCheck2);
+
+var _createClass2 = require('babel-runtime/helpers/createClass');
+
+var _createClass3 = _interopRequireDefault(_createClass2);
+
+var _async = require('async');
+
+var _async2 = _interopRequireDefault(_async);
+
+var _request = require('request');
+
+var _request2 = _interopRequireDefault(_request);
+
+var _verror = require('verror');
+
+var _verror2 = _interopRequireDefault(_verror);
+
+var _lodash = require('lodash.find');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _lodash3 = require('lodash.reduce');
+
+var _lodash4 = _interopRequireDefault(_lodash3);
+
+var _helpers = require('./helpers');
+
+var _constants = require('./constants');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var RollbarSourceMapPlugin = function () {
+  function RollbarSourceMapPlugin(_ref) {
+    var accessToken = _ref.accessToken,
+        version = _ref.version,
+        publicPath = _ref.publicPath,
+        _ref$includeChunks = _ref.includeChunks,
+        includeChunks = _ref$includeChunks === undefined ? [] : _ref$includeChunks,
+        _ref$retries = _ref.retries,
+        retries = _ref$retries === undefined ? 1 : _ref$retries,
+        _ref$silent = _ref.silent,
+        silent = _ref$silent === undefined ? false : _ref$silent,
+        _ref$ignoreErrors = _ref.ignoreErrors,
+        ignoreErrors = _ref$ignoreErrors === undefined ? false : _ref$ignoreErrors;
+    (0, _classCallCheck3.default)(this, RollbarSourceMapPlugin);
+
+    this.accessToken = accessToken;
+    this.version = version;
+    this.publicPath = publicPath;
+    this.includeChunks = [].concat(includeChunks);
+    this.retries = retries;
+    this.silent = silent;
+    this.ignoreErrors = ignoreErrors;
+  }
+
+  (0, _createClass3.default)(RollbarSourceMapPlugin, [{
+    key: 'afterEmit',
+    value: function afterEmit(compilation, cb) {
+      var _this = this;
+
+      var errors = (0, _helpers.validateOptions)(this);
+
+      if (errors) {
+        var _compilation$errors;
+
+        (_compilation$errors = compilation.errors).push.apply(_compilation$errors, (0, _toConsumableArray3.default)((0, _helpers.handleError)(errors)));
+        return cb();
+      }
+
+      this.uploadSourceMaps(compilation, function (err) {
+        if (err) {
+          if (!_this.ignoreErrors) {
+            var _compilation$errors2;
+
+            (_compilation$errors2 = compilation.errors).push.apply(_compilation$errors2, (0, _toConsumableArray3.default)((0, _helpers.handleError)(err)));
+          } else if (!_this.silent) {
+            var _compilation$warnings;
+
+            (_compilation$warnings = compilation.warnings).push.apply(_compilation$warnings, (0, _toConsumableArray3.default)((0, _helpers.handleError)(err)));
+          }
+        }
+        cb();
+      });
+    }
+  }, {
+    key: 'apply',
+    value: function apply(compiler) {
+      compiler.plugin('after-emit', this.afterEmit.bind(this));
+    }
+  }, {
+    key: 'getAssets',
+    value: function getAssets(compilation) {
+      var includeChunks = this.includeChunks;
+
+      var _compilation$getStats = compilation.getStats().toJson(),
+          chunks = _compilation$getStats.chunks;
+
+      return (0, _lodash4.default)(chunks, function (result, chunk) {
+        var chunkName = chunk.names[0];
+        if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
+          return result;
+        }
+
+        var sourceFile = (0, _lodash2.default)(chunk.files, function (file) {
+          return (/\.js$/.test(file)
+          );
+        });
+        var sourceMap = (0, _lodash2.default)(chunk.files, function (file) {
+          return (/\.js\.map$/.test(file)
+          );
+        });
+
+        if (!sourceFile || !sourceMap) {
+          return result;
+        }
+
+        return [].concat((0, _toConsumableArray3.default)(result), [{ sourceFile: sourceFile, sourceMap: sourceMap }]);
+      }, {});
+    }
+  }, {
+    key: 'uploadSourceMap',
+    value: function uploadSourceMap(compilation, _ref2, cb) {
+      var sourceFile = _ref2.sourceFile,
+          sourceMap = _ref2.sourceMap;
+
+      _async2.default.retry({ times: this.retries, interval: 100 }, function (callback) {
+        var req = _request2.default.post(_constants.ROLLBAR_ENDPOINT, function (err, res, body) {
+          if (!err && res.statusCode !== 200) {
+            callback(new Error(''), res, body);
+            return;
+          }
+
+          callback(err, res, body);
+        });
+
+        var form = req.form();
+        form.append('access_token', this.accessToken);
+        form.append('version', this.version);
+        form.append('minified_url', this.publicPath + '/' + sourceFile);
+        form.append('source_map', compilation.assets[sourceMap].source(), {
+          filename: sourceMap,
+          contentType: 'application/json'
+        });
+      }.bind(this), function (err, res, body) {
+        if (res && res.statusCode === 200) {
+          if (!this.silent) {
+            console.info('Uploaded ' + sourceMap + ' to Rollbar'); // eslint-disable-line no-console
+          }
+          return cb();
+        }
+
+        var errMessage = 'failed to upload ' + sourceMap + ' to Rollbar';
+        if (err && err.message) {
+          return cb(new _verror2.default(err, errMessage));
+        }
+
+        try {
+          var _JSON$parse = JSON.parse(body),
+              message = _JSON$parse.message;
+
+          return cb(new Error(message ? errMessage + ': ' + message : errMessage));
+        } catch (parseErr) {
+          return cb(new _verror2.default(parseErr, errMessage));
+        }
+      }.bind(this));
+    }
+  }, {
+    key: 'uploadSourceMaps',
+    value: function uploadSourceMaps(compilation, cb) {
+      var assets = this.getAssets(compilation);
+      var upload = this.uploadSourceMap.bind(this, compilation);
+
+      _async2.default.each(assets, upload, function (err, results) {
+        if (err) {
+          return cb(err);
+        }
+        return cb(null, results);
+      });
+    }
+  }]);
+  return RollbarSourceMapPlugin;
+}();
+
+module.exports = RollbarSourceMapPlugin;

--- a/dist/constants.js
+++ b/dist/constants.js
@@ -1,0 +1,8 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var ROLLBAR_ENDPOINT = exports.ROLLBAR_ENDPOINT = 'https://api.rollbar.com/api/1/sourcemap';
+
+var ROLLBAR_REQ_FIELDS = exports.ROLLBAR_REQ_FIELDS = ['accessToken', 'version', 'publicPath'];

--- a/dist/helpers.js
+++ b/dist/helpers.js
@@ -1,0 +1,49 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _toConsumableArray2 = require('babel-runtime/helpers/toConsumableArray');
+
+var _toConsumableArray3 = _interopRequireDefault(_toConsumableArray2);
+
+exports.handleError = handleError;
+exports.validateOptions = validateOptions;
+
+var _verror = require('verror');
+
+var _verror2 = _interopRequireDefault(_verror);
+
+var _constants = require('./constants');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// Take a single Error or array of Errors and return an array of errors that
+// have message prefixed.
+function handleError(err) {
+  var prefix = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 'RollbarSourceMapPlugin';
+
+  if (!err) {
+    return [];
+  }
+
+  var errors = [].concat(err);
+  return errors.map(function (e) {
+    return new _verror2.default(e, prefix);
+  });
+}
+
+// Validate required options and return an array of errors or null if there
+// are no errors.
+function validateOptions(ref) {
+  var errors = _constants.ROLLBAR_REQ_FIELDS.reduce(function (result, field) {
+    if (ref && ref[field]) {
+      return result;
+    }
+
+    return [].concat((0, _toConsumableArray3.default)(result), [new Error('required field, \'' + field + '\', is missing.')]);
+  }, []);
+
+  return errors.length ? errors : null;
+}

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -400,7 +400,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
         expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload'
+          message: 'failed to upload vendor.5190.js.map to Rollbar with status code 422: missing source_map file upload'
         });
         done();
       });
@@ -418,7 +418,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
         expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload'
+          message: 'failed to upload vendor.5190.js.map to Rollbar with status code 422: missing source_map file upload'
         });
         done();
       });
@@ -432,7 +432,24 @@ describe('RollbarSourceMapPlugin', function() {
       const { compilation, chunk } = this;
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
-        expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
+        expect(err).toInclude({
+          message: 'failed to upload vendor.5190.js.map to Rollbar with status code 422: failed to parse : Unexpected end of JSON input'
+        });
+        done();
+      });
+    });
+
+    it('should handle non JSON error responses', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(403, '<Error>Boom</Error>');
+
+      const { compilation, chunk } = this;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        expect(err).toExist();
+        expect(err).toInclude({
+          message: 'failed to upload vendor.5190.js.map to Rollbar with status code 403: failed to parse <Error>Boom</Error>: Unexpected token < in JSON at position 0'
+        });
         done();
       });
     });
@@ -448,7 +465,7 @@ describe('RollbarSourceMapPlugin', function() {
       const { compilation, chunk } = this;
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
-        expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
+        expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar with status code 422: [\w\s]+/);
         done();
       });
     });
@@ -461,8 +478,8 @@ describe('RollbarSourceMapPlugin', function() {
       const { compilation, chunk } = this;
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
-        expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened'
+        expect(err).toMatch({
+          message: 'something awful happened'
         });
         done();
       });
@@ -479,8 +496,8 @@ describe('RollbarSourceMapPlugin', function() {
       const { compilation, chunk } = this;
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
-        expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened'
+        expect(err).toMatch({
+          message: 'something awful happened'
         });
         done();
       });


### PR DESCRIPTION
Sometimes when there are multiple sourcemap files the upload to rollbar may fail.
In order to address this issue we added retry policy using async-retry.