### PR TITLE
Support configurable Rollbar sourcemap endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ If `false`, success and warning messages will be logged to the console for each 
 #### `ignoreErrors: boolean` **(default: `false`)**
 Set to `true` to bypass adding upload errors to the webpack compilation. Do this if you do not want to fail the build when sourcemap uploads fail. If you do not want to fail the build but you do want to see the failures as warnings, make sure `silent` option is set to `false`.
 
+#### `rollbarEndpoint: string` **(default: `https://api.rollbar.com/api/1/sourcemap`)**
+A string defining the Rollbar API endpoint to upload the sourcemaps to. It can be used for self-hosted Rollbar instances.
+
 ## App Configuration
 - The web app should have [rollbar-browser](https://github.com/rollbar/rollbar.js) installed and configured for webpack as described [here](https://github.com/rollbar/rollbar.js/tree/master/examples/webpack#using-rollbar-with-webpack).
 - See the [Rollbar source map](https://rollbar.com/docs/source-maps/) documentation

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -13,7 +13,8 @@ class RollbarSourceMapPlugin {
     publicPath,
     includeChunks = [],
     silent = false,
-    ignoreErrors = false
+    ignoreErrors = false,
+    rollbarEndpoint = ROLLBAR_ENDPOINT
   }) {
     this.accessToken = accessToken;
     this.version = version;
@@ -21,6 +22,7 @@ class RollbarSourceMapPlugin {
     this.includeChunks = [].concat(includeChunks);
     this.silent = silent;
     this.ignoreErrors = ignoreErrors;
+    this.rollbarEndpoint = rollbarEndpoint;
   }
 
   afterEmit(compilation, cb) {
@@ -72,7 +74,7 @@ class RollbarSourceMapPlugin {
   }
 
   uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
-    const req = request.post(ROLLBAR_ENDPOINT, (err, res, body) => {
+    const req = request.post(this.rollbarEndpoint, (err, res, body) => {
       if (!err && res.statusCode === 200) {
         if (!this.silent) {
           console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -1,6 +1,7 @@
 import expect, { isSpy, spyOn, createSpy } from 'expect';
 import nock from 'nock';
 import RollbarSourceMapPlugin from '../src/RollbarSourceMapPlugin';
+import { ROLLBAR_ENDPOINT } from '../src/constants';
 
 describe('RollbarSourceMapPlugin', function() {
   beforeEach(function() {
@@ -64,6 +65,17 @@ describe('RollbarSourceMapPlugin', function() {
       });
       const plugin = new RollbarSourceMapPlugin(options);
       expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
+    });
+
+    it('should default rollbarEndpoint to ROLLBAR_ENDPOINT constant', function() {
+      expect(this.plugin).toInclude({ rollbarEndpoint: ROLLBAR_ENDPOINT });
+    });
+
+    it('should access string value for rollbarEndpoint', function() {
+      const customEndpoint = 'https://api.rollbar.custom.com/api/1/sourcemap';
+      const options = Object.assign({}, this.options, { rollbarEndpoint: customEndpoint });
+      const plugin = new RollbarSourceMapPlugin(options);
+      expect(plugin).toInclude({ rollbarEndpoint: customEndpoint });
     });
   });
 


### PR DESCRIPTION
This change is to allow the plugin to take an optional Rollbar sourcemap endpoint, to allow for self-hosted Rollbar instances.