### PR TITLE
Support webpack 4 hooks API

### DIFF
--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -46,7 +46,11 @@ class RollbarSourceMapPlugin {
   }
 
   apply(compiler) {
-    compiler.plugin('after-emit', this.afterEmit.bind(this));
+    if (compiler.hooks) {
+      compiler.hooks.afterEmit.tapAsync('after-emit', this.afterEmit.bind(this));
+    } else {
+      compiler.plugin('after-emit', this.afterEmit.bind(this));
+    }
   }
 
   getAssets(compilation) {

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -8,6 +8,11 @@ describe('RollbarSourceMapPlugin', function() {
     this.compiler = {
       options: {},
       plugin: createSpy(),
+      hooks: {
+        afterEmit: {
+          tapAsync: createSpy()
+        },
+      },
       resolvers: {
         loader: {
           plugin: createSpy(),
@@ -27,8 +32,6 @@ describe('RollbarSourceMapPlugin', function() {
     };
 
     this.plugin = new RollbarSourceMapPlugin(this.options);
-
-    this.plugin.apply(this.compiler);
   });
 
   describe('constructor', function() {
@@ -80,7 +83,18 @@ describe('RollbarSourceMapPlugin', function() {
   });
 
   describe('apply', function() {
-    it('should hook into `after-emit"', function() {
+    it('should hook into "after-emit"', function() {
+      this.plugin.apply(this.compiler);
+      expect(this.compiler.hooks.afterEmit.tapAsync.calls.length).toBe(1);
+      expect(this.compiler.hooks.afterEmit.tapAsync.calls[0].arguments).toEqual([
+        'after-emit',
+        this.plugin.afterEmit.bind(this.plugin)
+      ]);
+    });
+
+    it('should plug into `after-emit" when "hooks" is undefined', function() {
+      delete this.compiler.hooks;
+      this.plugin.apply(this.compiler);
       expect(this.compiler.plugin.calls.length).toBe(1);
       expect(this.compiler.plugin.calls[0].arguments).toEqual([
         'after-emit',


### PR DESCRIPTION
Hello,

This PR supports the new `.hooks` API in webpack 4 https://webpack.js.org/api/plugins/. It should remove the warning `DepreciationWarning: Tappable.plugin is deprecated. Use new API on '.hooks'`. 

The PR is backwards compatible with the old `.plugin` API. If this is something you're interested in merging I'm happy to make whatever changes are necessary.

-Colin
