### PR TITLE
Feature/public path as function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Your rollbar `post_server_item` access token.
 A string identifying the version of your code this source map package is for. Typically this will be the full git sha.
 
 #### `publicPath: string | function(string): string` **(required)**
-The base url for the cdn where your production bundles are hosted or a function that receives the source file local address and returns the url for that file in the cdn where your production bundles are hosted.
+The base url for the cdn where your production bundles are hosted or a function that receives the source file local address and returns the url for that file in the cdn where your production bundles are hosted. You should use the function form when your project has some kind of divergence between url routes and actual folder structure. For example: NextJs projects can serve bundled files in the following url `http://my.app/_next/123abc123abc123/page/home.js` but have a folder structure like this `APP_ROOT/build/bundles/pages/home.js`. The function form allows you to transform the final public url in order to conform with your routing needs.
 
 #### `includeChunks: string | [string]` **(optional)**
 An array of chunks for which sourcemaps should be uploaded. This should correspond to the names in the webpack config `entry` field. If there's only one chunk, it can be a string rather than an array. If not supplied, all sourcemaps emitted by webpack will be uploaded, including those for unnamed chunks.

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ Your rollbar `post_server_item` access token.
 #### `version: string` **(required)**
 A string identifying the version of your code this source map package is for. Typically this will be the full git sha.
 
-#### `publicPath: string` **(required)**
-The base url for the cdn where your production bundles are hosted.
+#### `publicPath: string | function(string): string` **(required)**
+The base url for the cdn where your production bundles are hosted or a function that receives the source file local address and returns the url for that file in the cdn where your production bundles are hosted.
 
 #### `includeChunks: string | [string]` **(optional)**
 An array of chunks for which sourcemaps should be uploaded. This should correspond to the names in the webpack config `entry` field. If there's only one chunk, it can be a string rather than an array. If not supplied, all sourcemaps emitted by webpack will be uploaded, including those for unnamed chunks.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3729,6 +3729,16 @@
       "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
       "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM="
     },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
     "lodash.reduce": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,8 @@
     "babel-runtime": "^6.26.0",
     "lodash.find": "^4.3.0",
     "lodash.foreach": "^4.2.0",
+    "lodash.isfunction": "^3.0.9",
+    "lodash.isstring": "^4.0.1",
     "lodash.reduce": "^4.3.0",
     "request": "^2.85.0",
     "verror": "^1.6.1"

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -3,6 +3,7 @@ import request from 'request';
 import VError from 'verror';
 import find from 'lodash.find';
 import reduce from 'lodash.reduce';
+import isString from 'lodash.isstring';
 import { handleError, validateOptions } from './helpers';
 import { ROLLBAR_ENDPOINT } from './constants';
 
@@ -77,6 +78,13 @@ class RollbarSourceMapPlugin {
     }, {});
   }
 
+  getPublicPath(sourceFile) {
+    if (isString(this.publicPath)) {
+      return `${this.publicPath}/${sourceFile}`;
+    }
+    return this.publicPath(sourceFile);
+  }
+
   uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
     const req = request.post(this.rollbarEndpoint, (err, res, body) => {
       if (!err && res.statusCode === 200) {
@@ -102,7 +110,7 @@ class RollbarSourceMapPlugin {
     const form = req.form();
     form.append('access_token', this.accessToken);
     form.append('version', this.version);
-    form.append('minified_url', `${this.publicPath}/${sourceFile}`);
+    form.append('minified_url', this.getPublicPath(sourceFile));
     form.append('source_map', compilation.assets[sourceMap].source(), {
       filename: sourceMap,
       contentType: 'application/json'

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,4 +1,6 @@
 import VError from 'verror';
+import isFunction from 'lodash.isfunction';
+import isString from 'lodash.isstring';
 import { ROLLBAR_REQ_FIELDS } from './constants';
 
 // Take a single Error or array of Errors and return an array of errors that
@@ -16,6 +18,16 @@ export function handleError(err, prefix = 'RollbarSourceMapPlugin') {
 // are no errors.
 export function validateOptions(ref) {
   const errors = ROLLBAR_REQ_FIELDS.reduce((result, field) => {
+    if (field === 'publicPath'
+        && ref && ref[field]
+        && !isString(ref[field])
+        && !isFunction(ref[field])) {
+      return [
+        ...result,
+        new TypeError(`invalid type. '${field}' expected to be string or function.`)
+      ];
+    }
+
     if (ref && ref[field]) {
       return result;
     }

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -199,6 +199,30 @@ describe('RollbarSourceMapPlugin', function() {
     });
   });
 
+  describe('getPublicPath', function() {
+    beforeEach(function() {
+      this.options = {
+        accessToken: 'aaaabbbbccccddddeeeeffff00001111',
+        version: 'master-latest-sha',
+        publicPath: 'https://my.cdn.net/assets'
+      };
+      this.sourceFile = 'vendor.5190.js';
+    });
+
+    it('should return \'publicPath\' value if it\'s a string', function() {
+      const plugin = new RollbarSourceMapPlugin(this.options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
+    });
+
+    it('should return whatever is returned by publicPath argument when it\'s a function', function () {
+      const options = Object.assign({}, this.options, { publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}` });
+      const plugin = new RollbarSourceMapPlugin(options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
+    });
+  });
+
   describe('getAssets', function() {
     beforeEach(function() {
       this.chunks = [

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -118,5 +118,28 @@ describe('helpers', function() {
       expect(result).toBeA(Array);
       expect(result.length).toBe(ROLLBAR_REQ_FIELDS.length);
     });
+
+    it('should return an error if publicPath is not a string nor a function', function () {
+      const options = {
+        accessToken: 'aaabbbccc000111',
+        version: 'latest',
+        publicPath: 3
+      };
+      const result = helpers.validateOptions(options);
+      expect(result).toBeA(Array);
+      expect(result.length).toBe(1);
+      expect(result[0]).toBeA(TypeError)
+        .toInclude({ message: 'invalid type. \'publicPath\' expected to be string or function.' });
+    });
+
+    it('should return null if all required arguments are provided and accept a function as the publicPath argument', function () {
+      const options = {
+        accessToken: 'aaabbbccc000111',
+        version: 'latest',
+        publicPath: () => {}
+      };
+      const result = helpers.validateOptions(options);
+      expect(result).toBe(null);
+    });
   });
 });


### PR DESCRIPTION
Hello there,

Thank you for the work you guys have put into this. This package is saving us lots of time.

This PR intends to make a backward compatible API change on the publicPath argument. It would now accept publicPath to be **`string`** or a **`function(string): string`**.

This change would enable users with specific routing needs, as for example NextJs users, to apply whatever routing logic they need to the publicPath of each file. It works by using the function return as the public path for that source file.

I have seen some forks trying to achieve a similar feature with approaches that might be too centered in their own edge cases. I think this approach is more flexible and can attend more user without adding breaking changes.