### PR TITLE
Make clear that there were no breaking changes in v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 ## [v2.0.0](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/tree/v2.0.0) (2017-03-06)
 [Full Changelog](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/compare/v1.7.0...v2.0.0)
 
+**NOTE: THERE WERE NO BREAKING CHANGES IN THIS RELEASE**
+
 **Implemented enhancements:**
 
 - Add a simple working example for usage in an Angular app [\#6](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/6)


### PR DESCRIPTION
There were no breaking changes in v2. It's unclear why a major version was released without breaking changes, but that's done.

This just updates the `CHANGELOG` entry for v2 to make it clear that there are no breaking changes. This was confirmed in https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/59