### PR TITLE
fix asset filter regexp

### DIFF
--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -64,8 +64,8 @@ class RollbarSourceMapPlugin {
         return result;
       }
 
-      const sourceFile = find(chunk.files, file => /\.js$/.test(file));
-      const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
+      const sourceFile = find(chunk.files, file => /\.js/.test(file));
+      const sourceMap = find(chunk.files, file => /\.js\.map/.test(file));
 
       if (!sourceFile || !sourceMap) {
         return result;


### PR DESCRIPTION
When the chunk filename contains some hash to prevent caching, the current RegExp doesn't match on it.

E.g.: bundle.js?294a7a040655b15e1615