### PR TITLE
Replace afterEmit Hook with emit Hook

### DIFF
--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -8,127 +8,127 @@ import { handleError, validateOptions } from './helpers';
 import { ROLLBAR_ENDPOINT } from './constants';
 
 class RollbarSourceMapPlugin {
-    constructor({
-        accessToken,
-        version,
-        publicPath,
-        includeChunks = [],
-        silent = false,
-        ignoreErrors = false,
-        rollbarEndpoint = ROLLBAR_ENDPOINT,
-    }) {
-        this.accessToken = accessToken;
-        this.version = version;
-        this.publicPath = publicPath;
-        this.includeChunks = [].concat(includeChunks);
-        this.silent = silent;
-        this.ignoreErrors = ignoreErrors;
-        this.rollbarEndpoint = rollbarEndpoint;
+  constructor({
+    accessToken,
+    version,
+    publicPath,
+    includeChunks = [],
+    silent = false,
+    ignoreErrors = false,
+    rollbarEndpoint = ROLLBAR_ENDPOINT,
+  }) {
+    this.accessToken = accessToken;
+    this.version = version;
+    this.publicPath = publicPath;
+    this.includeChunks = [].concat(includeChunks);
+    this.silent = silent;
+    this.ignoreErrors = ignoreErrors;
+    this.rollbarEndpoint = rollbarEndpoint;
+  }
+
+  emit(compilation, cb) {
+    const errors = validateOptions(this);
+
+    if (errors) {
+      compilation.errors.push(...handleError(errors));
+      return cb();
     }
 
-    emit(compilation, cb) {
-        const errors = validateOptions(this);
+    this.uploadSourceMaps(compilation, (err) => {
+      if (err) {
+        if (!this.ignoreErrors) {
+          compilation.errors.push(...handleError(err));
+        } else if (!this.silent) {
+          compilation.warnings.push(...handleError(err));
+        }
+      }
+      cb();
+    });
+  }
 
-        if (errors) {
-            compilation.errors.push(...handleError(errors));
-            return cb();
+  apply(compiler) {
+    if (compiler.hooks) {
+      compiler.hooks.emit.tapAsync('emit', this.emit.bind(this));
+    } else {
+      compiler.plugin('emit', this.emit.bind(this));
+    }
+  }
+
+  getAssets(compilation) {
+    const { includeChunks } = this;
+    const { chunks } = compilation.getStats().toJson();
+
+    return reduce(
+      chunks,
+      (result, chunk) => {
+        const chunkName = chunk.names[0];
+        if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
+          return result;
         }
 
-        this.uploadSourceMaps(compilation, err => {
-            if (err) {
-                if (!this.ignoreErrors) {
-                    compilation.errors.push(...handleError(err));
-                } else if (!this.silent) {
-                    compilation.warnings.push(...handleError(err));
-                }
-            }
-            cb();
-        });
-    }
+        const sourceFile = find(chunk.files, file => /\.js$/.test(file));
+        const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
 
-    apply(compiler) {
-        if (compiler.hooks) {
-            compiler.hooks.emit.tapAsync('emit', this.emit.bind(this));
-        } else {
-            compiler.plugin('emit', this.emit.bind(this));
+        if (!sourceFile || !sourceMap) {
+          return result;
         }
+
+        return [...result, { sourceFile, sourceMap }];
+      },
+      {}
+    );
+  }
+
+  getPublicPath(sourceFile) {
+    if (isString(this.publicPath)) {
+      return `${this.publicPath}/${sourceFile}`;
     }
+    return this.publicPath(sourceFile);
+  }
 
-    getAssets(compilation) {
-        const { includeChunks } = this;
-        const { chunks } = compilation.getStats().toJson();
-
-        return reduce(
-            chunks,
-            (result, chunk) => {
-                const chunkName = chunk.names[0];
-                if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
-                    return result;
-                }
-
-                const sourceFile = find(chunk.files, file => /\.js$/.test(file));
-                const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
-
-                if (!sourceFile || !sourceMap) {
-                    return result;
-                }
-
-                return [...result, { sourceFile, sourceMap }];
-            },
-            {}
-        );
-    }
-
-    getPublicPath(sourceFile) {
-        if (isString(this.publicPath)) {
-            return `${this.publicPath}/${sourceFile}`;
+  uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
+    const req = request.post(this.rollbarEndpoint, (err, res, body) => {
+      if (!err && res.statusCode === 200) {
+        if (!this.silent) {
+          console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
         }
-        return this.publicPath(sourceFile);
-    }
+        return cb();
+      }
 
-    uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
-        const req = request.post(this.rollbarEndpoint, (err, res, body) => {
-            if (!err && res.statusCode === 200) {
-                if (!this.silent) {
-                    console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
-                }
-                return cb();
-            }
+      const errMessage = `failed to upload ${sourceMap} to Rollbar`;
+      if (err) {
+        return cb(new VError(err, errMessage));
+      }
 
-            const errMessage = `failed to upload ${sourceMap} to Rollbar`;
-            if (err) {
-                return cb(new VError(err, errMessage));
-            }
+      try {
+        const { message } = JSON.parse(body);
+        return cb(new Error(message ? `${errMessage}: ${message}` : errMessage));
+      } catch (parseErr) {
+        return cb(new VError(parseErr, errMessage));
+      }
+    });
 
-            try {
-                const { message } = JSON.parse(body);
-                return cb(new Error(message ? `${errMessage}: ${message}` : errMessage));
-            } catch (parseErr) {
-                return cb(new VError(parseErr, errMessage));
-            }
-        });
+    const form = req.form();
+    form.append('access_token', this.accessToken);
+    form.append('version', this.version);
+    form.append('minified_url', this.getPublicPath(sourceFile));
+    form.append('source_map', compilation.assets[sourceMap].source(), {
+      filename: sourceMap,
+      contentType: 'application/json',
+    });
+  }
 
-        const form = req.form();
-        form.append('access_token', this.accessToken);
-        form.append('version', this.version);
-        form.append('minified_url', this.getPublicPath(sourceFile));
-        form.append('source_map', compilation.assets[sourceMap].source(), {
-            filename: sourceMap,
-            contentType: 'application/json',
-        });
-    }
+  uploadSourceMaps(compilation, cb) {
+    const assets = this.getAssets(compilation);
+    const upload = this.uploadSourceMap.bind(this, compilation);
 
-    uploadSourceMaps(compilation, cb) {
-        const assets = this.getAssets(compilation);
-        const upload = this.uploadSourceMap.bind(this, compilation);
-
-        async.each(assets, upload, (err, results) => {
-            if (err) {
-                return cb(err);
-            }
-            return cb(null, results);
-        });
-    }
+    async.each(assets, upload, (err, results) => {
+      if (err) {
+        return cb(err);
+      }
+      return cb(null, results);
+    });
+  }
 }
 
 module.exports = RollbarSourceMapPlugin;

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -15,7 +15,7 @@ class RollbarSourceMapPlugin {
     includeChunks = [],
     silent = false,
     ignoreErrors = false,
-    rollbarEndpoint = ROLLBAR_ENDPOINT,
+    rollbarEndpoint = ROLLBAR_ENDPOINT
   }) {
     this.accessToken = accessToken;
     this.version = version;
@@ -58,25 +58,24 @@ class RollbarSourceMapPlugin {
     const { includeChunks } = this;
     const { chunks } = compilation.getStats().toJson();
 
-    return reduce(
-      chunks,
-      (result, chunk) => {
-        const chunkName = chunk.names[0];
-        if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
-          return result;
-        }
+    return reduce(chunks, (result, chunk) => {
+      const chunkName = chunk.names[0];
+      if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
+        return result;
+      }
 
-        const sourceFile = find(chunk.files, file => /\.js$/.test(file));
-        const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
+      const sourceFile = find(chunk.files, file => /\.js$/.test(file));
+      const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
 
-        if (!sourceFile || !sourceMap) {
-          return result;
-        }
+      if (!sourceFile || !sourceMap) {
+        return result;
+      }
 
-        return [...result, { sourceFile, sourceMap }];
-      },
-      {}
-    );
+      return [
+        ...result,
+        { sourceFile, sourceMap }
+      ];
+    }, {});
   }
 
   getPublicPath(sourceFile) {
@@ -114,7 +113,7 @@ class RollbarSourceMapPlugin {
     form.append('minified_url', this.getPublicPath(sourceFile));
     form.append('source_map', compilation.assets[sourceMap].source(), {
       filename: sourceMap,
-      contentType: 'application/json',
+      contentType: 'application/json'
     });
   }
 

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -8,126 +8,127 @@ import { handleError, validateOptions } from './helpers';
 import { ROLLBAR_ENDPOINT } from './constants';
 
 class RollbarSourceMapPlugin {
-  constructor({
-    accessToken,
-    version,
-    publicPath,
-    includeChunks = [],
-    silent = false,
-    ignoreErrors = false,
-    rollbarEndpoint = ROLLBAR_ENDPOINT
-  }) {
-    this.accessToken = accessToken;
-    this.version = version;
-    this.publicPath = publicPath;
-    this.includeChunks = [].concat(includeChunks);
-    this.silent = silent;
-    this.ignoreErrors = ignoreErrors;
-    this.rollbarEndpoint = rollbarEndpoint;
-  }
-
-  afterEmit(compilation, cb) {
-    const errors = validateOptions(this);
-
-    if (errors) {
-      compilation.errors.push(...handleError(errors));
-      return cb();
+    constructor({
+        accessToken,
+        version,
+        publicPath,
+        includeChunks = [],
+        silent = false,
+        ignoreErrors = false,
+        rollbarEndpoint = ROLLBAR_ENDPOINT,
+    }) {
+        this.accessToken = accessToken;
+        this.version = version;
+        this.publicPath = publicPath;
+        this.includeChunks = [].concat(includeChunks);
+        this.silent = silent;
+        this.ignoreErrors = ignoreErrors;
+        this.rollbarEndpoint = rollbarEndpoint;
     }
 
-    this.uploadSourceMaps(compilation, (err) => {
-      if (err) {
-        if (!this.ignoreErrors) {
-          compilation.errors.push(...handleError(err));
-        } else if (!this.silent) {
-          compilation.warnings.push(...handleError(err));
+    emit(compilation, cb) {
+        const errors = validateOptions(this);
+
+        if (errors) {
+            compilation.errors.push(...handleError(errors));
+            return cb();
         }
-      }
-      cb();
-    });
-  }
 
-  apply(compiler) {
-    if (compiler.hooks) {
-      compiler.hooks.afterEmit.tapAsync('after-emit', this.afterEmit.bind(this));
-    } else {
-      compiler.plugin('after-emit', this.afterEmit.bind(this));
+        this.uploadSourceMaps(compilation, err => {
+            if (err) {
+                if (!this.ignoreErrors) {
+                    compilation.errors.push(...handleError(err));
+                } else if (!this.silent) {
+                    compilation.warnings.push(...handleError(err));
+                }
+            }
+            cb();
+        });
     }
-  }
 
-  getAssets(compilation) {
-    const { includeChunks } = this;
-    const { chunks } = compilation.getStats().toJson();
-
-    return reduce(chunks, (result, chunk) => {
-      const chunkName = chunk.names[0];
-      if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
-        return result;
-      }
-
-      const sourceFile = find(chunk.files, file => /\.js$/.test(file));
-      const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
-
-      if (!sourceFile || !sourceMap) {
-        return result;
-      }
-
-      return [
-        ...result,
-        { sourceFile, sourceMap }
-      ];
-    }, {});
-  }
-
-  getPublicPath(sourceFile) {
-    if (isString(this.publicPath)) {
-      return `${this.publicPath}/${sourceFile}`;
-    }
-    return this.publicPath(sourceFile);
-  }
-
-  uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
-    const req = request.post(this.rollbarEndpoint, (err, res, body) => {
-      if (!err && res.statusCode === 200) {
-        if (!this.silent) {
-          console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
+    apply(compiler) {
+        if (compiler.hooks) {
+            compiler.hooks.emit.tapAsync('emit', this.emit.bind(this));
+        } else {
+            compiler.plugin('emit', this.emit.bind(this));
         }
-        return cb();
-      }
+    }
 
-      const errMessage = `failed to upload ${sourceMap} to Rollbar`;
-      if (err) {
-        return cb(new VError(err, errMessage));
-      }
+    getAssets(compilation) {
+        const { includeChunks } = this;
+        const { chunks } = compilation.getStats().toJson();
 
-      try {
-        const { message } = JSON.parse(body);
-        return cb(new Error(message ? `${errMessage}: ${message}` : errMessage));
-      } catch (parseErr) {
-        return cb(new VError(parseErr, errMessage));
-      }
-    });
+        return reduce(
+            chunks,
+            (result, chunk) => {
+                const chunkName = chunk.names[0];
+                if (includeChunks.length && includeChunks.indexOf(chunkName) === -1) {
+                    return result;
+                }
 
-    const form = req.form();
-    form.append('access_token', this.accessToken);
-    form.append('version', this.version);
-    form.append('minified_url', this.getPublicPath(sourceFile));
-    form.append('source_map', compilation.assets[sourceMap].source(), {
-      filename: sourceMap,
-      contentType: 'application/json'
-    });
-  }
+                const sourceFile = find(chunk.files, file => /\.js$/.test(file));
+                const sourceMap = find(chunk.files, file => /\.js\.map$/.test(file));
 
-  uploadSourceMaps(compilation, cb) {
-    const assets = this.getAssets(compilation);
-    const upload = this.uploadSourceMap.bind(this, compilation);
+                if (!sourceFile || !sourceMap) {
+                    return result;
+                }
 
-    async.each(assets, upload, (err, results) => {
-      if (err) {
-        return cb(err);
-      }
-      return cb(null, results);
-    });
-  }
+                return [...result, { sourceFile, sourceMap }];
+            },
+            {}
+        );
+    }
+
+    getPublicPath(sourceFile) {
+        if (isString(this.publicPath)) {
+            return `${this.publicPath}/${sourceFile}`;
+        }
+        return this.publicPath(sourceFile);
+    }
+
+    uploadSourceMap(compilation, { sourceFile, sourceMap }, cb) {
+        const req = request.post(this.rollbarEndpoint, (err, res, body) => {
+            if (!err && res.statusCode === 200) {
+                if (!this.silent) {
+                    console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
+                }
+                return cb();
+            }
+
+            const errMessage = `failed to upload ${sourceMap} to Rollbar`;
+            if (err) {
+                return cb(new VError(err, errMessage));
+            }
+
+            try {
+                const { message } = JSON.parse(body);
+                return cb(new Error(message ? `${errMessage}: ${message}` : errMessage));
+            } catch (parseErr) {
+                return cb(new VError(parseErr, errMessage));
+            }
+        });
+
+        const form = req.form();
+        form.append('access_token', this.accessToken);
+        form.append('version', this.version);
+        form.append('minified_url', this.getPublicPath(sourceFile));
+        form.append('source_map', compilation.assets[sourceMap].source(), {
+            filename: sourceMap,
+            contentType: 'application/json',
+        });
+    }
+
+    uploadSourceMaps(compilation, cb) {
+        const assets = this.getAssets(compilation);
+        const upload = this.uploadSourceMap.bind(this, compilation);
+
+        async.each(assets, upload, (err, results) => {
+            if (err) {
+                return cb(err);
+            }
+            return cb(null, results);
+        });
+    }
 }
 
 module.exports = RollbarSourceMapPlugin;

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -10,7 +10,7 @@ describe('RollbarSourceMapPlugin', function() {
       plugin: createSpy(),
       hooks: {
         emit: {
-          tapAsync: createSpy(),
+          tapAsync: createSpy()
         },
       },
       resolvers: {
@@ -28,7 +28,7 @@ describe('RollbarSourceMapPlugin', function() {
     this.options = {
       accessToken: 'aaaabbbbccccddddeeeeffff00001111',
       version: 'master-latest-sha',
-      publicPath: 'https://my.cdn.net/assets',
+      publicPath: 'https://my.cdn.net/assets'
     };
 
     this.plugin = new RollbarSourceMapPlugin(this.options);
@@ -42,7 +42,7 @@ describe('RollbarSourceMapPlugin', function() {
     it('should set options', function() {
       const options = Object.assign({}, this.options, {
         includeChunks: ['foo', 'bar'],
-        silent: true,
+        silent: true
       });
       const plugin = new RollbarSourceMapPlugin(options);
       expect(plugin).toInclude(options);
@@ -102,8 +102,8 @@ describe('RollbarSourceMapPlugin', function() {
 
   describe('emit', function() {
     beforeEach(function() {
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((compilation, callback) =>
-        callback());
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
+        .andCall((compilation, callback) => callback());
     });
 
     afterEach(function() {
@@ -115,7 +115,7 @@ describe('RollbarSourceMapPlugin', function() {
     it('should call uploadSourceMaps', function(done) {
       const compilation = {
         errors: [],
-        warnings: [],
+        warnings: []
       };
       this.plugin.emit(compilation, () => {
         expect(this.uploadSourceMaps.calls.length).toBe(1);
@@ -125,26 +125,24 @@ describe('RollbarSourceMapPlugin', function() {
       });
     });
 
-    it(
-      'should add upload warnings to compilation warnings, ' + 'if ignoreErrors is true and silent is false',
-      function(done) {
-        const compilation = {
-          errors: [],
-          warnings: [],
-        };
-        this.plugin.ignoreErrors = true;
-        this.plugin.silent = false;
-        this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-          callback(new Error()));
-        this.plugin.emit(compilation, () => {
-          expect(this.uploadSourceMaps.calls.length).toBe(1);
-          expect(compilation.errors.length).toBe(0);
-          expect(compilation.warnings.length).toBe(1);
-          expect(compilation.warnings[0]).toBeA(Error);
-          done();
-        });
-      }
-    );
+    it('should add upload warnings to compilation warnings, ' +
+      'if ignoreErrors is true and silent is false', function(done) {
+      const compilation = {
+        errors: [],
+        warnings: [],
+      };
+      this.plugin.ignoreErrors = true;
+      this.plugin.silent = false;
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
+        .andCall((comp, callback) => callback(new Error()));
+      this.plugin.emit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(1);
+        expect(compilation.errors.length).toBe(0);
+        expect(compilation.warnings.length).toBe(1);
+        expect(compilation.warnings[0]).toBeA(Error);
+        done();
+      });
+    });
 
     it('should not add upload errors to compilation warnings if silent is true', function(done) {
       const compilation = {
@@ -153,8 +151,8 @@ describe('RollbarSourceMapPlugin', function() {
       };
       this.plugin.ignoreErrors = true;
       this.plugin.silent = true;
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-        callback(new Error()));
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
+        .andCall((comp, callback) => callback(new Error()));
       this.plugin.emit(compilation, () => {
         expect(this.uploadSourceMaps.calls.length).toBe(1);
         expect(compilation.errors.length).toBe(0);
@@ -166,11 +164,11 @@ describe('RollbarSourceMapPlugin', function() {
     it('should add upload errors to compilation errors', function(done) {
       const compilation = {
         errors: [],
-        warnings: [],
+        warnings: []
       };
       this.plugin.ignoreErrors = false;
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-        callback(new Error()));
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
+        .andCall((comp, callback) => callback(new Error()));
       this.plugin.emit(compilation, () => {
         expect(this.uploadSourceMaps.calls.length).toBe(1);
         expect(compilation.warnings.length).toBe(0);
@@ -183,12 +181,12 @@ describe('RollbarSourceMapPlugin', function() {
     it('should add validation errors to compilation', function(done) {
       const compilation = {
         errors: [],
-        warnings: [],
+        warnings: []
       };
 
       this.plugin = new RollbarSourceMapPlugin({
         version: 'master-latest-sha',
-        publicPath: 'https://my.cdn.net/assets',
+        publicPath: 'https://my.cdn.net/assets'
       });
       this.plugin.emit(compilation, () => {
         expect(this.uploadSourceMaps.calls.length).toBe(0);
@@ -203,21 +201,19 @@ describe('RollbarSourceMapPlugin', function() {
       this.options = {
         accessToken: 'aaaabbbbccccddddeeeeffff00001111',
         version: 'master-latest-sha',
-        publicPath: 'https://my.cdn.net/assets',
+        publicPath: 'https://my.cdn.net/assets'
       };
       this.sourceFile = 'vendor.5190.js';
     });
 
-    it("should return 'publicPath' value if it's a string", function() {
+    it('should return \'publicPath\' value if it\'s a string', function() {
       const plugin = new RollbarSourceMapPlugin(this.options);
       const result = plugin.getPublicPath(this.sourceFile);
       expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
     });
 
-    it("should return whatever is returned by publicPath argument when it's a function", function() {
-      const options = Object.assign({}, this.options, {
-        publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}`,
-      });
+    it('should return whatever is returned by publicPath argument when it\'s a function', function() {
+      const options = Object.assign({}, this.options, { publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}` });
       const plugin = new RollbarSourceMapPlugin(options);
       const result = plugin.getPublicPath(this.sourceFile);
       expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
@@ -231,17 +227,16 @@ describe('RollbarSourceMapPlugin', function() {
           id: 0,
           names: ['vendor'],
           files: ['vendor.5190.js', 'vendor.5190.js.map'],
-        },
-        {
+        }, {
           id: 1,
           names: ['app'],
           files: ['app.81c1.js', 'app.81c1.js.map'],
-        },
+        }
       ];
       this.compilation = {
         getStats: () => ({
-          toJson: () => ({ chunks: this.chunks }),
-        }),
+          toJson: () => ({ chunks: this.chunks })
+        })
       };
     });
 
@@ -249,7 +244,7 @@ describe('RollbarSourceMapPlugin', function() {
       const assets = this.plugin.getAssets(this.compilation);
       expect(assets).toEqual([
         { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
       ]);
     });
 
@@ -258,16 +253,17 @@ describe('RollbarSourceMapPlugin', function() {
         {
           id: 0,
           names: ['vendor'],
-          files: ['vendor.5190.js'],
-        },
-        {
+          files: ['vendor.5190.js']
+        }, {
           id: 1,
           names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map'],
-        },
+          files: ['app.81c1.js', 'app.81c1.js.map']
+        }
       ];
       const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
+      expect(assets).toEqual([
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
+      ]);
     });
 
     it('should include unnamed chunks when includeChunks is not specified', function() {
@@ -275,37 +271,36 @@ describe('RollbarSourceMapPlugin', function() {
         {
           id: 0,
           names: ['vendor'],
-          files: ['vendor.5190.js', 'vendor.5190.js.map'],
-        },
-        {
+          files: ['vendor.5190.js', 'vendor.5190.js.map']
+        }, {
           id: 1,
           names: [],
-          files: ['1.cfea.js', '1.cfea.js.map'],
-        },
-        {
+          files: ['1.cfea.js', '1.cfea.js.map']
+        }, {
           id: 2,
           names: [],
-          files: ['2-a364.js', '2-a364.js.map'],
-        },
-        {
+          files: ['2-a364.js', '2-a364.js.map']
+        }, {
           id: 3,
           names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map'],
-        },
+          files: ['app.81c1.js', 'app.81c1.js.map']
+        }
       ];
       const assets = this.plugin.getAssets(this.compilation);
       expect(assets).toEqual([
         { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
         { sourceFile: '1.cfea.js', sourceMap: '1.cfea.js.map' },
         { sourceFile: '2-a364.js', sourceMap: '2-a364.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
       ]);
     });
 
     it('should filter out chunks that are not in includeChunks', function() {
       this.plugin.includeChunks = ['app'];
       const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
+      expect(assets).toEqual([
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
+      ]);
     });
   });
 
@@ -317,7 +312,8 @@ describe('RollbarSourceMapPlugin', function() {
         { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
       ];
       this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
-      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) => callback());
+      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap')
+        .andCall((comp, chunk, callback) => callback());
     });
 
     afterEach(function() {
@@ -337,24 +333,22 @@ describe('RollbarSourceMapPlugin', function() {
         expect(this.compilation.errors.length).toBe(0);
         expect(this.uploadSourceMap.calls.length).toBe(2);
 
-        expect(this.uploadSourceMap.calls[0].arguments[0]).toEqual({ name: 'test', errors: [] });
-        expect(this.uploadSourceMap.calls[0].arguments[1]).toEqual({
-          sourceFile: 'vendor.5190.js',
-          sourceMap: 'vendor.5190.js.map',
-        });
+        expect(this.uploadSourceMap.calls[0].arguments[0])
+          .toEqual({ name: 'test', errors: [] });
+        expect(this.uploadSourceMap.calls[0].arguments[1])
+          .toEqual({ sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' });
 
-        expect(this.uploadSourceMap.calls[1].arguments[0]).toEqual({ name: 'test', errors: [] });
-        expect(this.uploadSourceMap.calls[1].arguments[1]).toEqual({
-          sourceFile: 'app.81c1.js',
-          sourceMap: 'app.81c1.js.map',
-        });
+        expect(this.uploadSourceMap.calls[1].arguments[0])
+          .toEqual({ name: 'test', errors: [] });
+        expect(this.uploadSourceMap.calls[1].arguments[1])
+          .toEqual({ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' });
         done();
       });
     });
 
     it('should call err-back if uploadSourceMap errors', function(done) {
-      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) =>
-        callback(new Error()));
+      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap')
+        .andCall((comp, chunk, callback) => callback(new Error()));
       this.plugin.uploadSourceMaps(this.compilation, (err, result) => {
         expect(err).toExist();
         expect(err).toBeA(Error);
@@ -370,14 +364,14 @@ describe('RollbarSourceMapPlugin', function() {
       this.compilation = {
         assets: {
           'vendor.5190.js.map': { source: () => '{"version":3,"sources":[]' },
-          'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' },
+          'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' }
         },
-        errors: [],
+        errors: []
       };
 
       this.chunk = {
         sourceFile: 'vendor.5190.js',
-        sourceMap: 'vendor.5190.js.map',
+        sourceMap: 'vendor.5190.js.map'
       };
     });
 
@@ -441,7 +435,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
         expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload',
+          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload'
         });
         done();
       });
@@ -469,7 +463,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.plugin.uploadSourceMap(compilation, chunk, (err) => {
         expect(err).toExist();
         expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened',
+          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened'
         });
         done();
       });

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -64,7 +64,7 @@ describe('RollbarSourceMapPlugin', function() {
 
     it('should accept array value for includeChunks', function() {
       const options = Object.assign({}, this.options, {
-        includeChunks: ['foo', 'bar'],
+        includeChunks: ['foo', 'bar']
       });
       const plugin = new RollbarSourceMapPlugin(options);
       expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
@@ -88,7 +88,7 @@ describe('RollbarSourceMapPlugin', function() {
       expect(this.compiler.hooks.emit.tapAsync.calls.length).toBe(1);
       expect(this.compiler.hooks.emit.tapAsync.calls[0].arguments).toEqual([
         'emit',
-        this.plugin.emit.bind(this.plugin),
+        this.plugin.emit.bind(this.plugin)
       ]);
     });
 
@@ -96,7 +96,10 @@ describe('RollbarSourceMapPlugin', function() {
       delete this.compiler.hooks;
       this.plugin.apply(this.compiler);
       expect(this.compiler.plugin.calls.length).toBe(1);
-      expect(this.compiler.plugin.calls[0].arguments).toEqual(['emit', this.plugin.emit.bind(this.plugin)]);
+      expect(this.compiler.plugin.calls[0].arguments).toEqual([
+        'emit',
+        this.plugin.emit.bind(this.plugin)
+      ]);
     });
   });
 
@@ -129,7 +132,7 @@ describe('RollbarSourceMapPlugin', function() {
       'if ignoreErrors is true and silent is false', function(done) {
       const compilation = {
         errors: [],
-        warnings: [],
+        warnings: []
       };
       this.plugin.ignoreErrors = true;
       this.plugin.silent = false;
@@ -147,7 +150,7 @@ describe('RollbarSourceMapPlugin', function() {
     it('should not add upload errors to compilation warnings if silent is true', function(done) {
       const compilation = {
         errors: [],
-        warnings: [],
+        warnings: []
       };
       this.plugin.ignoreErrors = true;
       this.plugin.silent = true;
@@ -212,7 +215,7 @@ describe('RollbarSourceMapPlugin', function() {
       expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
     });
 
-    it('should return whatever is returned by publicPath argument when it\'s a function', function() {
+    it('should return whatever is returned by publicPath argument when it\'s a function', function () {
       const options = Object.assign({}, this.options, { publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}` });
       const plugin = new RollbarSourceMapPlugin(options);
       const result = plugin.getPublicPath(this.sourceFile);
@@ -226,11 +229,11 @@ describe('RollbarSourceMapPlugin', function() {
         {
           id: 0,
           names: ['vendor'],
-          files: ['vendor.5190.js', 'vendor.5190.js.map'],
+          files: ['vendor.5190.js', 'vendor.5190.js.map']
         }, {
           id: 1,
           names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map'],
+          files: ['app.81c1.js', 'app.81c1.js.map']
         }
       ];
       this.compilation = {
@@ -309,7 +312,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.compilation = { name: 'test', errors: [] };
       this.assets = [
         { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
       ];
       this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
       this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap')

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -4,472 +4,480 @@ import RollbarSourceMapPlugin from '../src/RollbarSourceMapPlugin';
 import { ROLLBAR_ENDPOINT } from '../src/constants';
 
 describe('RollbarSourceMapPlugin', function() {
-  beforeEach(function() {
-    this.compiler = {
-      options: {},
-      plugin: createSpy(),
-      hooks: {
-        afterEmit: {
-          tapAsync: createSpy()
-        },
-      },
-      resolvers: {
-        loader: {
-          plugin: createSpy(),
-          resolve: createSpy(),
-        },
-        normal: {
-          plugin: createSpy(),
-          resolve: createSpy(),
-        },
-      },
-    };
-
-    this.options = {
-      accessToken: 'aaaabbbbccccddddeeeeffff00001111',
-      version: 'master-latest-sha',
-      publicPath: 'https://my.cdn.net/assets'
-    };
-
-    this.plugin = new RollbarSourceMapPlugin(this.options);
-  });
-
-  describe('constructor', function() {
-    it('should return an instance', function() {
-      expect(this.plugin).toBeA(RollbarSourceMapPlugin);
-    });
-
-    it('should set options', function() {
-      const options = Object.assign({}, this.options, {
-        includeChunks: ['foo', 'bar'],
-        silent: true
-      });
-      const plugin = new RollbarSourceMapPlugin(options);
-      expect(plugin).toInclude(options);
-    });
-
-    it('should default silent to false', function() {
-      expect(this.plugin).toInclude({ silent: false });
-    });
-
-    it('should default includeChunks to []', function() {
-      expect(this.plugin).toInclude({ includeChunks: [] });
-    });
-
-    it('should accept string value for includeChunks', function() {
-      const options = Object.assign({}, this.options, { includeChunks: 'foo' });
-      const plugin = new RollbarSourceMapPlugin(options);
-      expect(plugin).toInclude({ includeChunks: ['foo'] });
-    });
-
-    it('should accept array value for includeChunks', function() {
-      const options = Object.assign({}, this.options, {
-        includeChunks: ['foo', 'bar']
-      });
-      const plugin = new RollbarSourceMapPlugin(options);
-      expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
-    });
-
-    it('should default rollbarEndpoint to ROLLBAR_ENDPOINT constant', function() {
-      expect(this.plugin).toInclude({ rollbarEndpoint: ROLLBAR_ENDPOINT });
-    });
-
-    it('should access string value for rollbarEndpoint', function() {
-      const customEndpoint = 'https://api.rollbar.custom.com/api/1/sourcemap';
-      const options = Object.assign({}, this.options, { rollbarEndpoint: customEndpoint });
-      const plugin = new RollbarSourceMapPlugin(options);
-      expect(plugin).toInclude({ rollbarEndpoint: customEndpoint });
-    });
-  });
-
-  describe('apply', function() {
-    it('should hook into "after-emit"', function() {
-      this.plugin.apply(this.compiler);
-      expect(this.compiler.hooks.afterEmit.tapAsync.calls.length).toBe(1);
-      expect(this.compiler.hooks.afterEmit.tapAsync.calls[0].arguments).toEqual([
-        'after-emit',
-        this.plugin.afterEmit.bind(this.plugin)
-      ]);
-    });
-
-    it('should plug into `after-emit" when "hooks" is undefined', function() {
-      delete this.compiler.hooks;
-      this.plugin.apply(this.compiler);
-      expect(this.compiler.plugin.calls.length).toBe(1);
-      expect(this.compiler.plugin.calls[0].arguments).toEqual([
-        'after-emit',
-        this.plugin.afterEmit.bind(this.plugin)
-      ]);
-    });
-  });
-
-  describe('afterEmit', function() {
     beforeEach(function() {
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
-        .andCall((compilation, callback) => callback());
+        this.compiler = {
+            options: {},
+            plugin: createSpy(),
+            hooks: {
+                emit: {
+                    tapAsync: createSpy(),
+                },
+            },
+            resolvers: {
+                loader: {
+                    plugin: createSpy(),
+                    resolve: createSpy(),
+                },
+                normal: {
+                    plugin: createSpy(),
+                    resolve: createSpy(),
+                },
+            },
+        };
+
+        this.options = {
+            accessToken: 'aaaabbbbccccddddeeeeffff00001111',
+            version: 'master-latest-sha',
+            publicPath: 'https://my.cdn.net/assets',
+        };
+
+        this.plugin = new RollbarSourceMapPlugin(this.options);
     });
 
-    afterEach(function() {
-      if (isSpy(this.uploadSourceMaps)) {
-        this.uploadSourceMaps.restore();
-      }
-    });
-
-    it('should call uploadSourceMaps', function(done) {
-      const compilation = {
-        errors: [],
-        warnings: []
-      };
-      this.plugin.afterEmit(compilation, () => {
-        expect(this.uploadSourceMaps.calls.length).toBe(1);
-        expect(compilation.errors.length).toBe(0);
-        expect(compilation.warnings.length).toBe(0);
-        done();
-      });
-    });
-
-    it('should add upload warnings to compilation warnings, ' +
-      'if ignoreErrors is true and silent is false', function(done) {
-      const compilation = {
-        errors: [],
-        warnings: []
-      };
-      this.plugin.ignoreErrors = true;
-      this.plugin.silent = false;
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
-        .andCall((comp, callback) => callback(new Error()));
-      this.plugin.afterEmit(compilation, () => {
-        expect(this.uploadSourceMaps.calls.length).toBe(1);
-        expect(compilation.errors.length).toBe(0);
-        expect(compilation.warnings.length).toBe(1);
-        expect(compilation.warnings[0]).toBeA(Error);
-        done();
-      });
-    });
-
-    it('should not add upload errors to compilation warnings if silent is true', function(done) {
-      const compilation = {
-        errors: [],
-        warnings: []
-      };
-      this.plugin.ignoreErrors = true;
-      this.plugin.silent = true;
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
-        .andCall((comp, callback) => callback(new Error()));
-      this.plugin.afterEmit(compilation, () => {
-        expect(this.uploadSourceMaps.calls.length).toBe(1);
-        expect(compilation.errors.length).toBe(0);
-        expect(compilation.warnings.length).toBe(0);
-        done();
-      });
-    });
-
-    it('should add upload errors to compilation errors', function(done) {
-      const compilation = {
-        errors: [],
-        warnings: []
-      };
-      this.plugin.ignoreErrors = false;
-      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps')
-        .andCall((comp, callback) => callback(new Error()));
-      this.plugin.afterEmit(compilation, () => {
-        expect(this.uploadSourceMaps.calls.length).toBe(1);
-        expect(compilation.warnings.length).toBe(0);
-        expect(compilation.errors.length).toBe(1);
-        expect(compilation.errors[0]).toBeA(Error);
-        done();
-      });
-    });
-
-    it('should add validation errors to compilation', function(done) {
-      const compilation = {
-        errors: [],
-        warnings: []
-      };
-
-      this.plugin = new RollbarSourceMapPlugin({
-        version: 'master-latest-sha',
-        publicPath: 'https://my.cdn.net/assets'
-      });
-      this.plugin.afterEmit(compilation, () => {
-        expect(this.uploadSourceMaps.calls.length).toBe(0);
-        expect(compilation.errors.length).toBe(1);
-        done();
-      });
-    });
-  });
-
-  describe('getPublicPath', function() {
-    beforeEach(function() {
-      this.options = {
-        accessToken: 'aaaabbbbccccddddeeeeffff00001111',
-        version: 'master-latest-sha',
-        publicPath: 'https://my.cdn.net/assets'
-      };
-      this.sourceFile = 'vendor.5190.js';
-    });
-
-    it('should return \'publicPath\' value if it\'s a string', function() {
-      const plugin = new RollbarSourceMapPlugin(this.options);
-      const result = plugin.getPublicPath(this.sourceFile);
-      expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
-    });
-
-    it('should return whatever is returned by publicPath argument when it\'s a function', function () {
-      const options = Object.assign({}, this.options, { publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}` });
-      const plugin = new RollbarSourceMapPlugin(options);
-      const result = plugin.getPublicPath(this.sourceFile);
-      expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
-    });
-  });
-
-  describe('getAssets', function() {
-    beforeEach(function() {
-      this.chunks = [
-        {
-          id: 0,
-          names: ['vendor'],
-          files: ['vendor.5190.js', 'vendor.5190.js.map']
-        }, {
-          id: 1,
-          names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map']
-        }
-      ];
-      this.compilation = {
-        getStats: () => ({
-          toJson: () => ({ chunks: this.chunks })
-        })
-      };
-    });
-
-    it('should return an array of js, sourcemap tuples', function() {
-      const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([
-        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
-      ]);
-    });
-
-    it('should ignore chunks that do not have a sourcemap asset', function() {
-      this.chunks = [
-        {
-          id: 0,
-          names: ['vendor'],
-          files: ['vendor.5190.js']
-        }, {
-          id: 1,
-          names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map']
-        }
-      ];
-      const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
-      ]);
-    });
-
-    it('should include unnamed chunks when includeChunks is not specified', function() {
-      this.chunks = [
-        {
-          id: 0,
-          names: ['vendor'],
-          files: ['vendor.5190.js', 'vendor.5190.js.map']
-        }, {
-          id: 1,
-          names: [],
-          files: ['1.cfea.js', '1.cfea.js.map']
-        }, {
-          id: 2,
-          names: [],
-          files: ['2-a364.js', '2-a364.js.map']
-        }, {
-          id: 3,
-          names: ['app'],
-          files: ['app.81c1.js', 'app.81c1.js.map']
-        }
-      ];
-      const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([
-        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-        { sourceFile: '1.cfea.js', sourceMap: '1.cfea.js.map' },
-        { sourceFile: '2-a364.js', sourceMap: '2-a364.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
-      ]);
-    });
-
-    it('should filter out chunks that are not in includeChunks', function() {
-      this.plugin.includeChunks = ['app'];
-      const assets = this.plugin.getAssets(this.compilation);
-      expect(assets).toEqual([
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
-      ]);
-    });
-  });
-
-  describe('uploadSourceMaps', function() {
-    beforeEach(function() {
-      this.compilation = { name: 'test', errors: [] };
-      this.assets = [
-        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }
-      ];
-      this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
-      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap')
-        .andCall((comp, chunk, callback) => callback());
-    });
-
-    afterEach(function() {
-      [this.getAssets, this.uploadSourceMap].forEach((func) => {
-        if (isSpy(func)) {
-          func.restore();
-        }
-      });
-    });
-
-    it('should call uploadSourceMap for each chunk', function(done) {
-      this.plugin.uploadSourceMaps(this.compilation, (err) => {
-        if (err) {
-          return done(err);
-        }
-        expect(this.getAssets.calls.length).toBe(1);
-        expect(this.compilation.errors.length).toBe(0);
-        expect(this.uploadSourceMap.calls.length).toBe(2);
-
-        expect(this.uploadSourceMap.calls[0].arguments[0])
-          .toEqual({ name: 'test', errors: [] });
-        expect(this.uploadSourceMap.calls[0].arguments[1])
-          .toEqual({ sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' });
-
-        expect(this.uploadSourceMap.calls[1].arguments[0])
-          .toEqual({ name: 'test', errors: [] });
-        expect(this.uploadSourceMap.calls[1].arguments[1])
-          .toEqual({ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' });
-        done();
-      });
-    });
-
-    it('should call err-back if uploadSourceMap errors', function(done) {
-      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap')
-        .andCall((comp, chunk, callback) => callback(new Error()));
-      this.plugin.uploadSourceMaps(this.compilation, (err, result) => {
-        expect(err).toExist();
-        expect(err).toBeA(Error);
-        expect(result).toBe(undefined);
-        done();
-      });
-    });
-  });
-
-  describe('uploadSourceMap', function() {
-    beforeEach(function() {
-      this.info = spyOn(console, 'info');
-      this.compilation = {
-        assets: {
-          'vendor.5190.js.map': { source: () => '{"version":3,"sources":[]' },
-          'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' }
-        },
-        errors: []
-      };
-
-      this.chunk = {
-        sourceFile: 'vendor.5190.js',
-        sourceMap: 'vendor.5190.js.map'
-      };
-    });
-
-    afterEach(function() {
-      this.info.restore();
-    });
-
-    it('should callback without err param if upload is success', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-      const { compilation, chunk } = this;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        if (err) {
-          return done(err);
-        }
-        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
-        done();
-      });
-    });
-
-    it('should not log upload to console if silent option is true', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-      const { compilation, chunk } = this;
-      this.plugin.silent = true;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        if (err) {
-          return done(err);
-        }
-        expect(this.info).toNotHaveBeenCalled();
-        done();
-      });
-    });
-
-    it('should log upload to console if silent option is false', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-      const { compilation, chunk } = this;
-      this.plugin.silent = false;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        if (err) {
-          return done(err);
-        }
-        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
-        done();
-      });
-    });
-
-    it('should return error message if failure response includes message', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .reply(422, JSON.stringify({ err: 1, message: 'missing source_map file upload' }));
-
-      const { compilation, chunk } = this;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        expect(err).toExist();
-        expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload'
+    describe('constructor', function() {
+        it('should return an instance', function() {
+            expect(this.plugin).toBeA(RollbarSourceMapPlugin);
         });
-        done();
-      });
-    });
 
-    it('should handle error response with empty body', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .reply(422, null);
-
-      const { compilation, chunk } = this;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        expect(err).toExist();
-        expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
-        done();
-      });
-    });
-
-    it('should handle HTTP request error', function(done) {
-      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-        .post('/api/1/sourcemap')
-        .replyWithError('something awful happened');
-
-      const { compilation, chunk } = this;
-      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
-        expect(err).toExist();
-        expect(err).toInclude({
-          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened'
+        it('should set options', function() {
+            const options = Object.assign({}, this.options, {
+                includeChunks: ['foo', 'bar'],
+                silent: true,
+            });
+            const plugin = new RollbarSourceMapPlugin(options);
+            expect(plugin).toInclude(options);
         });
-        done();
-      });
+
+        it('should default silent to false', function() {
+            expect(this.plugin).toInclude({ silent: false });
+        });
+
+        it('should default includeChunks to []', function() {
+            expect(this.plugin).toInclude({ includeChunks: [] });
+        });
+
+        it('should accept string value for includeChunks', function() {
+            const options = Object.assign({}, this.options, { includeChunks: 'foo' });
+            const plugin = new RollbarSourceMapPlugin(options);
+            expect(plugin).toInclude({ includeChunks: ['foo'] });
+        });
+
+        it('should accept array value for includeChunks', function() {
+            const options = Object.assign({}, this.options, {
+                includeChunks: ['foo', 'bar'],
+            });
+            const plugin = new RollbarSourceMapPlugin(options);
+            expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
+        });
+
+        it('should default rollbarEndpoint to ROLLBAR_ENDPOINT constant', function() {
+            expect(this.plugin).toInclude({ rollbarEndpoint: ROLLBAR_ENDPOINT });
+        });
+
+        it('should access string value for rollbarEndpoint', function() {
+            const customEndpoint = 'https://api.rollbar.custom.com/api/1/sourcemap';
+            const options = Object.assign({}, this.options, { rollbarEndpoint: customEndpoint });
+            const plugin = new RollbarSourceMapPlugin(options);
+            expect(plugin).toInclude({ rollbarEndpoint: customEndpoint });
+        });
     });
-  });
+
+    describe('apply', function() {
+        it('should hook into "emit"', function() {
+            this.plugin.apply(this.compiler);
+            expect(this.compiler.hooks.emit.tapAsync.calls.length).toBe(1);
+            expect(this.compiler.hooks.emit.tapAsync.calls[0].arguments).toEqual([
+                'emit',
+                this.plugin.emit.bind(this.plugin),
+            ]);
+        });
+
+        it('should plug into `emit" when "hooks" is undefined', function() {
+            delete this.compiler.hooks;
+            this.plugin.apply(this.compiler);
+            expect(this.compiler.plugin.calls.length).toBe(1);
+            expect(this.compiler.plugin.calls[0].arguments).toEqual(['emit', this.plugin.emit.bind(this.plugin)]);
+        });
+    });
+
+    describe('emit', function() {
+        beforeEach(function() {
+            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((compilation, callback) =>
+                callback()
+            );
+        });
+
+        afterEach(function() {
+            if (isSpy(this.uploadSourceMaps)) {
+                this.uploadSourceMaps.restore();
+            }
+        });
+
+        it('should call uploadSourceMaps', function(done) {
+            const compilation = {
+                errors: [],
+                warnings: [],
+            };
+            this.plugin.emit(compilation, () => {
+                expect(this.uploadSourceMaps.calls.length).toBe(1);
+                expect(compilation.errors.length).toBe(0);
+                expect(compilation.warnings.length).toBe(0);
+                done();
+            });
+        });
+
+        it(
+            'should add upload warnings to compilation warnings, ' + 'if ignoreErrors is true and silent is false',
+            function(done) {
+                const compilation = {
+                    errors: [],
+                    warnings: [],
+                };
+                this.plugin.ignoreErrors = true;
+                this.plugin.silent = false;
+                this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+                    callback(new Error())
+                );
+                this.plugin.emit(compilation, () => {
+                    expect(this.uploadSourceMaps.calls.length).toBe(1);
+                    expect(compilation.errors.length).toBe(0);
+                    expect(compilation.warnings.length).toBe(1);
+                    expect(compilation.warnings[0]).toBeA(Error);
+                    done();
+                });
+            }
+        );
+
+        it('should not add upload errors to compilation warnings if silent is true', function(done) {
+            const compilation = {
+                errors: [],
+                warnings: [],
+            };
+            this.plugin.ignoreErrors = true;
+            this.plugin.silent = true;
+            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+                callback(new Error())
+            );
+            this.plugin.emit(compilation, () => {
+                expect(this.uploadSourceMaps.calls.length).toBe(1);
+                expect(compilation.errors.length).toBe(0);
+                expect(compilation.warnings.length).toBe(0);
+                done();
+            });
+        });
+
+        it('should add upload errors to compilation errors', function(done) {
+            const compilation = {
+                errors: [],
+                warnings: [],
+            };
+            this.plugin.ignoreErrors = false;
+            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+                callback(new Error())
+            );
+            this.plugin.emit(compilation, () => {
+                expect(this.uploadSourceMaps.calls.length).toBe(1);
+                expect(compilation.warnings.length).toBe(0);
+                expect(compilation.errors.length).toBe(1);
+                expect(compilation.errors[0]).toBeA(Error);
+                done();
+            });
+        });
+
+        it('should add validation errors to compilation', function(done) {
+            const compilation = {
+                errors: [],
+                warnings: [],
+            };
+
+            this.plugin = new RollbarSourceMapPlugin({
+                version: 'master-latest-sha',
+                publicPath: 'https://my.cdn.net/assets',
+            });
+            this.plugin.emit(compilation, () => {
+                expect(this.uploadSourceMaps.calls.length).toBe(0);
+                expect(compilation.errors.length).toBe(1);
+                done();
+            });
+        });
+    });
+
+    describe('getPublicPath', function() {
+        beforeEach(function() {
+            this.options = {
+                accessToken: 'aaaabbbbccccddddeeeeffff00001111',
+                version: 'master-latest-sha',
+                publicPath: 'https://my.cdn.net/assets',
+            };
+            this.sourceFile = 'vendor.5190.js';
+        });
+
+        it("should return 'publicPath' value if it's a string", function() {
+            const plugin = new RollbarSourceMapPlugin(this.options);
+            const result = plugin.getPublicPath(this.sourceFile);
+            expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
+        });
+
+        it("should return whatever is returned by publicPath argument when it's a function", function() {
+            const options = Object.assign({}, this.options, {
+                publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}`,
+            });
+            const plugin = new RollbarSourceMapPlugin(options);
+            const result = plugin.getPublicPath(this.sourceFile);
+            expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
+        });
+    });
+
+    describe('getAssets', function() {
+        beforeEach(function() {
+            this.chunks = [
+                {
+                    id: 0,
+                    names: ['vendor'],
+                    files: ['vendor.5190.js', 'vendor.5190.js.map'],
+                },
+                {
+                    id: 1,
+                    names: ['app'],
+                    files: ['app.81c1.js', 'app.81c1.js.map'],
+                },
+            ];
+            this.compilation = {
+                getStats: () => ({
+                    toJson: () => ({ chunks: this.chunks }),
+                }),
+            };
+        });
+
+        it('should return an array of js, sourcemap tuples', function() {
+            const assets = this.plugin.getAssets(this.compilation);
+            expect(assets).toEqual([
+                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+            ]);
+        });
+
+        it('should ignore chunks that do not have a sourcemap asset', function() {
+            this.chunks = [
+                {
+                    id: 0,
+                    names: ['vendor'],
+                    files: ['vendor.5190.js'],
+                },
+                {
+                    id: 1,
+                    names: ['app'],
+                    files: ['app.81c1.js', 'app.81c1.js.map'],
+                },
+            ];
+            const assets = this.plugin.getAssets(this.compilation);
+            expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
+        });
+
+        it('should include unnamed chunks when includeChunks is not specified', function() {
+            this.chunks = [
+                {
+                    id: 0,
+                    names: ['vendor'],
+                    files: ['vendor.5190.js', 'vendor.5190.js.map'],
+                },
+                {
+                    id: 1,
+                    names: [],
+                    files: ['1.cfea.js', '1.cfea.js.map'],
+                },
+                {
+                    id: 2,
+                    names: [],
+                    files: ['2-a364.js', '2-a364.js.map'],
+                },
+                {
+                    id: 3,
+                    names: ['app'],
+                    files: ['app.81c1.js', 'app.81c1.js.map'],
+                },
+            ];
+            const assets = this.plugin.getAssets(this.compilation);
+            expect(assets).toEqual([
+                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+                { sourceFile: '1.cfea.js', sourceMap: '1.cfea.js.map' },
+                { sourceFile: '2-a364.js', sourceMap: '2-a364.js.map' },
+                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+            ]);
+        });
+
+        it('should filter out chunks that are not in includeChunks', function() {
+            this.plugin.includeChunks = ['app'];
+            const assets = this.plugin.getAssets(this.compilation);
+            expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
+        });
+    });
+
+    describe('uploadSourceMaps', function() {
+        beforeEach(function() {
+            this.compilation = { name: 'test', errors: [] };
+            this.assets = [
+                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+            ];
+            this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
+            this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) => callback());
+        });
+
+        afterEach(function() {
+            [this.getAssets, this.uploadSourceMap].forEach(func => {
+                if (isSpy(func)) {
+                    func.restore();
+                }
+            });
+        });
+
+        it('should call uploadSourceMap for each chunk', function(done) {
+            this.plugin.uploadSourceMaps(this.compilation, err => {
+                if (err) {
+                    return done(err);
+                }
+                expect(this.getAssets.calls.length).toBe(1);
+                expect(this.compilation.errors.length).toBe(0);
+                expect(this.uploadSourceMap.calls.length).toBe(2);
+
+                expect(this.uploadSourceMap.calls[0].arguments[0]).toEqual({ name: 'test', errors: [] });
+                expect(this.uploadSourceMap.calls[0].arguments[1]).toEqual({
+                    sourceFile: 'vendor.5190.js',
+                    sourceMap: 'vendor.5190.js.map',
+                });
+
+                expect(this.uploadSourceMap.calls[1].arguments[0]).toEqual({ name: 'test', errors: [] });
+                expect(this.uploadSourceMap.calls[1].arguments[1]).toEqual({
+                    sourceFile: 'app.81c1.js',
+                    sourceMap: 'app.81c1.js.map',
+                });
+                done();
+            });
+        });
+
+        it('should call err-back if uploadSourceMap errors', function(done) {
+            this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) =>
+                callback(new Error())
+            );
+            this.plugin.uploadSourceMaps(this.compilation, (err, result) => {
+                expect(err).toExist();
+                expect(err).toBeA(Error);
+                expect(result).toBe(undefined);
+                done();
+            });
+        });
+    });
+
+    describe('uploadSourceMap', function() {
+        beforeEach(function() {
+            this.info = spyOn(console, 'info');
+            this.compilation = {
+                assets: {
+                    'vendor.5190.js.map': { source: () => '{"version":3,"sources":[]' },
+                    'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' },
+                },
+                errors: [],
+            };
+
+            this.chunk = {
+                sourceFile: 'vendor.5190.js',
+                sourceMap: 'vendor.5190.js.map',
+            };
+        });
+
+        afterEach(function() {
+            this.info.restore();
+        });
+
+        it('should callback without err param if upload is success', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+            const { compilation, chunk } = this;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                if (err) {
+                    return done(err);
+                }
+                expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
+                done();
+            });
+        });
+
+        it('should not log upload to console if silent option is true', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+            const { compilation, chunk } = this;
+            this.plugin.silent = true;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                if (err) {
+                    return done(err);
+                }
+                expect(this.info).toNotHaveBeenCalled();
+                done();
+            });
+        });
+
+        it('should log upload to console if silent option is false', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+            const { compilation, chunk } = this;
+            this.plugin.silent = false;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                if (err) {
+                    return done(err);
+                }
+                expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
+                done();
+            });
+        });
+
+        it('should return error message if failure response includes message', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .reply(422, JSON.stringify({ err: 1, message: 'missing source_map file upload' }));
+
+            const { compilation, chunk } = this;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                expect(err).toExist();
+                expect(err).toInclude({
+                    message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload',
+                });
+                done();
+            });
+        });
+
+        it('should handle error response with empty body', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .reply(422, null);
+
+            const { compilation, chunk } = this;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                expect(err).toExist();
+                expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
+                done();
+            });
+        });
+
+        it('should handle HTTP request error', function(done) {
+            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+                .post('/api/1/sourcemap')
+                .replyWithError('something awful happened');
+
+            const { compilation, chunk } = this;
+            this.plugin.uploadSourceMap(compilation, chunk, err => {
+                expect(err).toExist();
+                expect(err).toInclude({
+                    message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened',
+                });
+                done();
+            });
+        });
+    });
 });

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -4,480 +4,475 @@ import RollbarSourceMapPlugin from '../src/RollbarSourceMapPlugin';
 import { ROLLBAR_ENDPOINT } from '../src/constants';
 
 describe('RollbarSourceMapPlugin', function() {
+  beforeEach(function() {
+    this.compiler = {
+      options: {},
+      plugin: createSpy(),
+      hooks: {
+        emit: {
+          tapAsync: createSpy(),
+        },
+      },
+      resolvers: {
+        loader: {
+          plugin: createSpy(),
+          resolve: createSpy(),
+        },
+        normal: {
+          plugin: createSpy(),
+          resolve: createSpy(),
+        },
+      },
+    };
+
+    this.options = {
+      accessToken: 'aaaabbbbccccddddeeeeffff00001111',
+      version: 'master-latest-sha',
+      publicPath: 'https://my.cdn.net/assets',
+    };
+
+    this.plugin = new RollbarSourceMapPlugin(this.options);
+  });
+
+  describe('constructor', function() {
+    it('should return an instance', function() {
+      expect(this.plugin).toBeA(RollbarSourceMapPlugin);
+    });
+
+    it('should set options', function() {
+      const options = Object.assign({}, this.options, {
+        includeChunks: ['foo', 'bar'],
+        silent: true,
+      });
+      const plugin = new RollbarSourceMapPlugin(options);
+      expect(plugin).toInclude(options);
+    });
+
+    it('should default silent to false', function() {
+      expect(this.plugin).toInclude({ silent: false });
+    });
+
+    it('should default includeChunks to []', function() {
+      expect(this.plugin).toInclude({ includeChunks: [] });
+    });
+
+    it('should accept string value for includeChunks', function() {
+      const options = Object.assign({}, this.options, { includeChunks: 'foo' });
+      const plugin = new RollbarSourceMapPlugin(options);
+      expect(plugin).toInclude({ includeChunks: ['foo'] });
+    });
+
+    it('should accept array value for includeChunks', function() {
+      const options = Object.assign({}, this.options, {
+        includeChunks: ['foo', 'bar'],
+      });
+      const plugin = new RollbarSourceMapPlugin(options);
+      expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
+    });
+
+    it('should default rollbarEndpoint to ROLLBAR_ENDPOINT constant', function() {
+      expect(this.plugin).toInclude({ rollbarEndpoint: ROLLBAR_ENDPOINT });
+    });
+
+    it('should access string value for rollbarEndpoint', function() {
+      const customEndpoint = 'https://api.rollbar.custom.com/api/1/sourcemap';
+      const options = Object.assign({}, this.options, { rollbarEndpoint: customEndpoint });
+      const plugin = new RollbarSourceMapPlugin(options);
+      expect(plugin).toInclude({ rollbarEndpoint: customEndpoint });
+    });
+  });
+
+  describe('apply', function() {
+    it('should hook into "emit"', function() {
+      this.plugin.apply(this.compiler);
+      expect(this.compiler.hooks.emit.tapAsync.calls.length).toBe(1);
+      expect(this.compiler.hooks.emit.tapAsync.calls[0].arguments).toEqual([
+        'emit',
+        this.plugin.emit.bind(this.plugin),
+      ]);
+    });
+
+    it('should plug into `emit" when "hooks" is undefined', function() {
+      delete this.compiler.hooks;
+      this.plugin.apply(this.compiler);
+      expect(this.compiler.plugin.calls.length).toBe(1);
+      expect(this.compiler.plugin.calls[0].arguments).toEqual(['emit', this.plugin.emit.bind(this.plugin)]);
+    });
+  });
+
+  describe('emit', function() {
     beforeEach(function() {
-        this.compiler = {
-            options: {},
-            plugin: createSpy(),
-            hooks: {
-                emit: {
-                    tapAsync: createSpy(),
-                },
-            },
-            resolvers: {
-                loader: {
-                    plugin: createSpy(),
-                    resolve: createSpy(),
-                },
-                normal: {
-                    plugin: createSpy(),
-                    resolve: createSpy(),
-                },
-            },
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((compilation, callback) =>
+        callback());
+    });
+
+    afterEach(function() {
+      if (isSpy(this.uploadSourceMaps)) {
+        this.uploadSourceMaps.restore();
+      }
+    });
+
+    it('should call uploadSourceMaps', function(done) {
+      const compilation = {
+        errors: [],
+        warnings: [],
+      };
+      this.plugin.emit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(1);
+        expect(compilation.errors.length).toBe(0);
+        expect(compilation.warnings.length).toBe(0);
+        done();
+      });
+    });
+
+    it(
+      'should add upload warnings to compilation warnings, ' + 'if ignoreErrors is true and silent is false',
+      function(done) {
+        const compilation = {
+          errors: [],
+          warnings: [],
         };
+        this.plugin.ignoreErrors = true;
+        this.plugin.silent = false;
+        this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+          callback(new Error()));
+        this.plugin.emit(compilation, () => {
+          expect(this.uploadSourceMaps.calls.length).toBe(1);
+          expect(compilation.errors.length).toBe(0);
+          expect(compilation.warnings.length).toBe(1);
+          expect(compilation.warnings[0]).toBeA(Error);
+          done();
+        });
+      }
+    );
 
-        this.options = {
-            accessToken: 'aaaabbbbccccddddeeeeffff00001111',
-            version: 'master-latest-sha',
-            publicPath: 'https://my.cdn.net/assets',
-        };
-
-        this.plugin = new RollbarSourceMapPlugin(this.options);
+    it('should not add upload errors to compilation warnings if silent is true', function(done) {
+      const compilation = {
+        errors: [],
+        warnings: [],
+      };
+      this.plugin.ignoreErrors = true;
+      this.plugin.silent = true;
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+        callback(new Error()));
+      this.plugin.emit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(1);
+        expect(compilation.errors.length).toBe(0);
+        expect(compilation.warnings.length).toBe(0);
+        done();
+      });
     });
 
-    describe('constructor', function() {
-        it('should return an instance', function() {
-            expect(this.plugin).toBeA(RollbarSourceMapPlugin);
-        });
-
-        it('should set options', function() {
-            const options = Object.assign({}, this.options, {
-                includeChunks: ['foo', 'bar'],
-                silent: true,
-            });
-            const plugin = new RollbarSourceMapPlugin(options);
-            expect(plugin).toInclude(options);
-        });
-
-        it('should default silent to false', function() {
-            expect(this.plugin).toInclude({ silent: false });
-        });
-
-        it('should default includeChunks to []', function() {
-            expect(this.plugin).toInclude({ includeChunks: [] });
-        });
-
-        it('should accept string value for includeChunks', function() {
-            const options = Object.assign({}, this.options, { includeChunks: 'foo' });
-            const plugin = new RollbarSourceMapPlugin(options);
-            expect(plugin).toInclude({ includeChunks: ['foo'] });
-        });
-
-        it('should accept array value for includeChunks', function() {
-            const options = Object.assign({}, this.options, {
-                includeChunks: ['foo', 'bar'],
-            });
-            const plugin = new RollbarSourceMapPlugin(options);
-            expect(plugin).toInclude({ includeChunks: ['foo', 'bar'] });
-        });
-
-        it('should default rollbarEndpoint to ROLLBAR_ENDPOINT constant', function() {
-            expect(this.plugin).toInclude({ rollbarEndpoint: ROLLBAR_ENDPOINT });
-        });
-
-        it('should access string value for rollbarEndpoint', function() {
-            const customEndpoint = 'https://api.rollbar.custom.com/api/1/sourcemap';
-            const options = Object.assign({}, this.options, { rollbarEndpoint: customEndpoint });
-            const plugin = new RollbarSourceMapPlugin(options);
-            expect(plugin).toInclude({ rollbarEndpoint: customEndpoint });
-        });
+    it('should add upload errors to compilation errors', function(done) {
+      const compilation = {
+        errors: [],
+        warnings: [],
+      };
+      this.plugin.ignoreErrors = false;
+      this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
+        callback(new Error()));
+      this.plugin.emit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(1);
+        expect(compilation.warnings.length).toBe(0);
+        expect(compilation.errors.length).toBe(1);
+        expect(compilation.errors[0]).toBeA(Error);
+        done();
+      });
     });
 
-    describe('apply', function() {
-        it('should hook into "emit"', function() {
-            this.plugin.apply(this.compiler);
-            expect(this.compiler.hooks.emit.tapAsync.calls.length).toBe(1);
-            expect(this.compiler.hooks.emit.tapAsync.calls[0].arguments).toEqual([
-                'emit',
-                this.plugin.emit.bind(this.plugin),
-            ]);
-        });
+    it('should add validation errors to compilation', function(done) {
+      const compilation = {
+        errors: [],
+        warnings: [],
+      };
 
-        it('should plug into `emit" when "hooks" is undefined', function() {
-            delete this.compiler.hooks;
-            this.plugin.apply(this.compiler);
-            expect(this.compiler.plugin.calls.length).toBe(1);
-            expect(this.compiler.plugin.calls[0].arguments).toEqual(['emit', this.plugin.emit.bind(this.plugin)]);
-        });
+      this.plugin = new RollbarSourceMapPlugin({
+        version: 'master-latest-sha',
+        publicPath: 'https://my.cdn.net/assets',
+      });
+      this.plugin.emit(compilation, () => {
+        expect(this.uploadSourceMaps.calls.length).toBe(0);
+        expect(compilation.errors.length).toBe(1);
+        done();
+      });
+    });
+  });
+
+  describe('getPublicPath', function() {
+    beforeEach(function() {
+      this.options = {
+        accessToken: 'aaaabbbbccccddddeeeeffff00001111',
+        version: 'master-latest-sha',
+        publicPath: 'https://my.cdn.net/assets',
+      };
+      this.sourceFile = 'vendor.5190.js';
     });
 
-    describe('emit', function() {
-        beforeEach(function() {
-            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((compilation, callback) =>
-                callback()
-            );
-        });
-
-        afterEach(function() {
-            if (isSpy(this.uploadSourceMaps)) {
-                this.uploadSourceMaps.restore();
-            }
-        });
-
-        it('should call uploadSourceMaps', function(done) {
-            const compilation = {
-                errors: [],
-                warnings: [],
-            };
-            this.plugin.emit(compilation, () => {
-                expect(this.uploadSourceMaps.calls.length).toBe(1);
-                expect(compilation.errors.length).toBe(0);
-                expect(compilation.warnings.length).toBe(0);
-                done();
-            });
-        });
-
-        it(
-            'should add upload warnings to compilation warnings, ' + 'if ignoreErrors is true and silent is false',
-            function(done) {
-                const compilation = {
-                    errors: [],
-                    warnings: [],
-                };
-                this.plugin.ignoreErrors = true;
-                this.plugin.silent = false;
-                this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-                    callback(new Error())
-                );
-                this.plugin.emit(compilation, () => {
-                    expect(this.uploadSourceMaps.calls.length).toBe(1);
-                    expect(compilation.errors.length).toBe(0);
-                    expect(compilation.warnings.length).toBe(1);
-                    expect(compilation.warnings[0]).toBeA(Error);
-                    done();
-                });
-            }
-        );
-
-        it('should not add upload errors to compilation warnings if silent is true', function(done) {
-            const compilation = {
-                errors: [],
-                warnings: [],
-            };
-            this.plugin.ignoreErrors = true;
-            this.plugin.silent = true;
-            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-                callback(new Error())
-            );
-            this.plugin.emit(compilation, () => {
-                expect(this.uploadSourceMaps.calls.length).toBe(1);
-                expect(compilation.errors.length).toBe(0);
-                expect(compilation.warnings.length).toBe(0);
-                done();
-            });
-        });
-
-        it('should add upload errors to compilation errors', function(done) {
-            const compilation = {
-                errors: [],
-                warnings: [],
-            };
-            this.plugin.ignoreErrors = false;
-            this.uploadSourceMaps = spyOn(this.plugin, 'uploadSourceMaps').andCall((comp, callback) =>
-                callback(new Error())
-            );
-            this.plugin.emit(compilation, () => {
-                expect(this.uploadSourceMaps.calls.length).toBe(1);
-                expect(compilation.warnings.length).toBe(0);
-                expect(compilation.errors.length).toBe(1);
-                expect(compilation.errors[0]).toBeA(Error);
-                done();
-            });
-        });
-
-        it('should add validation errors to compilation', function(done) {
-            const compilation = {
-                errors: [],
-                warnings: [],
-            };
-
-            this.plugin = new RollbarSourceMapPlugin({
-                version: 'master-latest-sha',
-                publicPath: 'https://my.cdn.net/assets',
-            });
-            this.plugin.emit(compilation, () => {
-                expect(this.uploadSourceMaps.calls.length).toBe(0);
-                expect(compilation.errors.length).toBe(1);
-                done();
-            });
-        });
+    it("should return 'publicPath' value if it's a string", function() {
+      const plugin = new RollbarSourceMapPlugin(this.options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
     });
 
-    describe('getPublicPath', function() {
-        beforeEach(function() {
-            this.options = {
-                accessToken: 'aaaabbbbccccddddeeeeffff00001111',
-                version: 'master-latest-sha',
-                publicPath: 'https://my.cdn.net/assets',
-            };
-            this.sourceFile = 'vendor.5190.js';
-        });
+    it("should return whatever is returned by publicPath argument when it's a function", function() {
+      const options = Object.assign({}, this.options, {
+        publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}`,
+      });
+      const plugin = new RollbarSourceMapPlugin(options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
+    });
+  });
 
-        it("should return 'publicPath' value if it's a string", function() {
-            const plugin = new RollbarSourceMapPlugin(this.options);
-            const result = plugin.getPublicPath(this.sourceFile);
-            expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
-        });
-
-        it("should return whatever is returned by publicPath argument when it's a function", function() {
-            const options = Object.assign({}, this.options, {
-                publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}`,
-            });
-            const plugin = new RollbarSourceMapPlugin(options);
-            const result = plugin.getPublicPath(this.sourceFile);
-            expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
-        });
+  describe('getAssets', function() {
+    beforeEach(function() {
+      this.chunks = [
+        {
+          id: 0,
+          names: ['vendor'],
+          files: ['vendor.5190.js', 'vendor.5190.js.map'],
+        },
+        {
+          id: 1,
+          names: ['app'],
+          files: ['app.81c1.js', 'app.81c1.js.map'],
+        },
+      ];
+      this.compilation = {
+        getStats: () => ({
+          toJson: () => ({ chunks: this.chunks }),
+        }),
+      };
     });
 
-    describe('getAssets', function() {
-        beforeEach(function() {
-            this.chunks = [
-                {
-                    id: 0,
-                    names: ['vendor'],
-                    files: ['vendor.5190.js', 'vendor.5190.js.map'],
-                },
-                {
-                    id: 1,
-                    names: ['app'],
-                    files: ['app.81c1.js', 'app.81c1.js.map'],
-                },
-            ];
-            this.compilation = {
-                getStats: () => ({
-                    toJson: () => ({ chunks: this.chunks }),
-                }),
-            };
-        });
-
-        it('should return an array of js, sourcemap tuples', function() {
-            const assets = this.plugin.getAssets(this.compilation);
-            expect(assets).toEqual([
-                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
-            ]);
-        });
-
-        it('should ignore chunks that do not have a sourcemap asset', function() {
-            this.chunks = [
-                {
-                    id: 0,
-                    names: ['vendor'],
-                    files: ['vendor.5190.js'],
-                },
-                {
-                    id: 1,
-                    names: ['app'],
-                    files: ['app.81c1.js', 'app.81c1.js.map'],
-                },
-            ];
-            const assets = this.plugin.getAssets(this.compilation);
-            expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
-        });
-
-        it('should include unnamed chunks when includeChunks is not specified', function() {
-            this.chunks = [
-                {
-                    id: 0,
-                    names: ['vendor'],
-                    files: ['vendor.5190.js', 'vendor.5190.js.map'],
-                },
-                {
-                    id: 1,
-                    names: [],
-                    files: ['1.cfea.js', '1.cfea.js.map'],
-                },
-                {
-                    id: 2,
-                    names: [],
-                    files: ['2-a364.js', '2-a364.js.map'],
-                },
-                {
-                    id: 3,
-                    names: ['app'],
-                    files: ['app.81c1.js', 'app.81c1.js.map'],
-                },
-            ];
-            const assets = this.plugin.getAssets(this.compilation);
-            expect(assets).toEqual([
-                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-                { sourceFile: '1.cfea.js', sourceMap: '1.cfea.js.map' },
-                { sourceFile: '2-a364.js', sourceMap: '2-a364.js.map' },
-                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
-            ]);
-        });
-
-        it('should filter out chunks that are not in includeChunks', function() {
-            this.plugin.includeChunks = ['app'];
-            const assets = this.plugin.getAssets(this.compilation);
-            expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
-        });
+    it('should return an array of js, sourcemap tuples', function() {
+      const assets = this.plugin.getAssets(this.compilation);
+      expect(assets).toEqual([
+        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+      ]);
     });
 
-    describe('uploadSourceMaps', function() {
-        beforeEach(function() {
-            this.compilation = { name: 'test', errors: [] };
-            this.assets = [
-                { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
-                { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
-            ];
-            this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
-            this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) => callback());
-        });
-
-        afterEach(function() {
-            [this.getAssets, this.uploadSourceMap].forEach(func => {
-                if (isSpy(func)) {
-                    func.restore();
-                }
-            });
-        });
-
-        it('should call uploadSourceMap for each chunk', function(done) {
-            this.plugin.uploadSourceMaps(this.compilation, err => {
-                if (err) {
-                    return done(err);
-                }
-                expect(this.getAssets.calls.length).toBe(1);
-                expect(this.compilation.errors.length).toBe(0);
-                expect(this.uploadSourceMap.calls.length).toBe(2);
-
-                expect(this.uploadSourceMap.calls[0].arguments[0]).toEqual({ name: 'test', errors: [] });
-                expect(this.uploadSourceMap.calls[0].arguments[1]).toEqual({
-                    sourceFile: 'vendor.5190.js',
-                    sourceMap: 'vendor.5190.js.map',
-                });
-
-                expect(this.uploadSourceMap.calls[1].arguments[0]).toEqual({ name: 'test', errors: [] });
-                expect(this.uploadSourceMap.calls[1].arguments[1]).toEqual({
-                    sourceFile: 'app.81c1.js',
-                    sourceMap: 'app.81c1.js.map',
-                });
-                done();
-            });
-        });
-
-        it('should call err-back if uploadSourceMap errors', function(done) {
-            this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) =>
-                callback(new Error())
-            );
-            this.plugin.uploadSourceMaps(this.compilation, (err, result) => {
-                expect(err).toExist();
-                expect(err).toBeA(Error);
-                expect(result).toBe(undefined);
-                done();
-            });
-        });
+    it('should ignore chunks that do not have a sourcemap asset', function() {
+      this.chunks = [
+        {
+          id: 0,
+          names: ['vendor'],
+          files: ['vendor.5190.js'],
+        },
+        {
+          id: 1,
+          names: ['app'],
+          files: ['app.81c1.js', 'app.81c1.js.map'],
+        },
+      ];
+      const assets = this.plugin.getAssets(this.compilation);
+      expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
     });
 
-    describe('uploadSourceMap', function() {
-        beforeEach(function() {
-            this.info = spyOn(console, 'info');
-            this.compilation = {
-                assets: {
-                    'vendor.5190.js.map': { source: () => '{"version":3,"sources":[]' },
-                    'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' },
-                },
-                errors: [],
-            };
-
-            this.chunk = {
-                sourceFile: 'vendor.5190.js',
-                sourceMap: 'vendor.5190.js.map',
-            };
-        });
-
-        afterEach(function() {
-            this.info.restore();
-        });
-
-        it('should callback without err param if upload is success', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-            const { compilation, chunk } = this;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                if (err) {
-                    return done(err);
-                }
-                expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
-                done();
-            });
-        });
-
-        it('should not log upload to console if silent option is true', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-            const { compilation, chunk } = this;
-            this.plugin.silent = true;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                if (err) {
-                    return done(err);
-                }
-                expect(this.info).toNotHaveBeenCalled();
-                done();
-            });
-        });
-
-        it('should log upload to console if silent option is false', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
-
-            const { compilation, chunk } = this;
-            this.plugin.silent = false;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                if (err) {
-                    return done(err);
-                }
-                expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
-                done();
-            });
-        });
-
-        it('should return error message if failure response includes message', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .reply(422, JSON.stringify({ err: 1, message: 'missing source_map file upload' }));
-
-            const { compilation, chunk } = this;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                expect(err).toExist();
-                expect(err).toInclude({
-                    message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload',
-                });
-                done();
-            });
-        });
-
-        it('should handle error response with empty body', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .reply(422, null);
-
-            const { compilation, chunk } = this;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                expect(err).toExist();
-                expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
-                done();
-            });
-        });
-
-        it('should handle HTTP request error', function(done) {
-            const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
-                .post('/api/1/sourcemap')
-                .replyWithError('something awful happened');
-
-            const { compilation, chunk } = this;
-            this.plugin.uploadSourceMap(compilation, chunk, err => {
-                expect(err).toExist();
-                expect(err).toInclude({
-                    message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened',
-                });
-                done();
-            });
-        });
+    it('should include unnamed chunks when includeChunks is not specified', function() {
+      this.chunks = [
+        {
+          id: 0,
+          names: ['vendor'],
+          files: ['vendor.5190.js', 'vendor.5190.js.map'],
+        },
+        {
+          id: 1,
+          names: [],
+          files: ['1.cfea.js', '1.cfea.js.map'],
+        },
+        {
+          id: 2,
+          names: [],
+          files: ['2-a364.js', '2-a364.js.map'],
+        },
+        {
+          id: 3,
+          names: ['app'],
+          files: ['app.81c1.js', 'app.81c1.js.map'],
+        },
+      ];
+      const assets = this.plugin.getAssets(this.compilation);
+      expect(assets).toEqual([
+        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+        { sourceFile: '1.cfea.js', sourceMap: '1.cfea.js.map' },
+        { sourceFile: '2-a364.js', sourceMap: '2-a364.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+      ]);
     });
+
+    it('should filter out chunks that are not in includeChunks', function() {
+      this.plugin.includeChunks = ['app'];
+      const assets = this.plugin.getAssets(this.compilation);
+      expect(assets).toEqual([{ sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' }]);
+    });
+  });
+
+  describe('uploadSourceMaps', function() {
+    beforeEach(function() {
+      this.compilation = { name: 'test', errors: [] };
+      this.assets = [
+        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' },
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+      ];
+      this.getAssets = spyOn(this.plugin, 'getAssets').andReturn(this.assets);
+      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) => callback());
+    });
+
+    afterEach(function() {
+      [this.getAssets, this.uploadSourceMap].forEach((func) => {
+        if (isSpy(func)) {
+          func.restore();
+        }
+      });
+    });
+
+    it('should call uploadSourceMap for each chunk', function(done) {
+      this.plugin.uploadSourceMaps(this.compilation, (err) => {
+        if (err) {
+          return done(err);
+        }
+        expect(this.getAssets.calls.length).toBe(1);
+        expect(this.compilation.errors.length).toBe(0);
+        expect(this.uploadSourceMap.calls.length).toBe(2);
+
+        expect(this.uploadSourceMap.calls[0].arguments[0]).toEqual({ name: 'test', errors: [] });
+        expect(this.uploadSourceMap.calls[0].arguments[1]).toEqual({
+          sourceFile: 'vendor.5190.js',
+          sourceMap: 'vendor.5190.js.map',
+        });
+
+        expect(this.uploadSourceMap.calls[1].arguments[0]).toEqual({ name: 'test', errors: [] });
+        expect(this.uploadSourceMap.calls[1].arguments[1]).toEqual({
+          sourceFile: 'app.81c1.js',
+          sourceMap: 'app.81c1.js.map',
+        });
+        done();
+      });
+    });
+
+    it('should call err-back if uploadSourceMap errors', function(done) {
+      this.uploadSourceMap = spyOn(this.plugin, 'uploadSourceMap').andCall((comp, chunk, callback) =>
+        callback(new Error()));
+      this.plugin.uploadSourceMaps(this.compilation, (err, result) => {
+        expect(err).toExist();
+        expect(err).toBeA(Error);
+        expect(result).toBe(undefined);
+        done();
+      });
+    });
+  });
+
+  describe('uploadSourceMap', function() {
+    beforeEach(function() {
+      this.info = spyOn(console, 'info');
+      this.compilation = {
+        assets: {
+          'vendor.5190.js.map': { source: () => '{"version":3,"sources":[]' },
+          'app.81c1.js.map': { source: () => '{"version":3,"sources":[]' },
+        },
+        errors: [],
+      };
+
+      this.chunk = {
+        sourceFile: 'vendor.5190.js',
+        sourceMap: 'vendor.5190.js.map',
+      };
+    });
+
+    afterEach(function() {
+      this.info.restore();
+    });
+
+    it('should callback without err param if upload is success', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+      const { compilation, chunk } = this;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        if (err) {
+          return done(err);
+        }
+        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
+        done();
+      });
+    });
+
+    it('should not log upload to console if silent option is true', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+      const { compilation, chunk } = this;
+      this.plugin.silent = true;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        if (err) {
+          return done(err);
+        }
+        expect(this.info).toNotHaveBeenCalled();
+        done();
+      });
+    });
+
+    it('should log upload to console if silent option is false', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(200, JSON.stringify({ err: 0, result: 'master-latest-sha' }));
+
+      const { compilation, chunk } = this;
+      this.plugin.silent = false;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        if (err) {
+          return done(err);
+        }
+        expect(this.info).toHaveBeenCalledWith('Uploaded vendor.5190.js.map to Rollbar');
+        done();
+      });
+    });
+
+    it('should return error message if failure response includes message', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(422, JSON.stringify({ err: 1, message: 'missing source_map file upload' }));
+
+      const { compilation, chunk } = this;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        expect(err).toExist();
+        expect(err).toInclude({
+          message: 'failed to upload vendor.5190.js.map to Rollbar: missing source_map file upload',
+        });
+        done();
+      });
+    });
+
+    it('should handle error response with empty body', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .reply(422, null);
+
+      const { compilation, chunk } = this;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        expect(err).toExist();
+        expect(err.message).toMatch(/failed to upload vendor\.5190.js\.map to Rollbar: [\w\s]+/);
+        done();
+      });
+    });
+
+    it('should handle HTTP request error', function(done) {
+      const scope = nock('https://api.rollbar.com:443') // eslint-disable-line no-unused-vars
+        .post('/api/1/sourcemap')
+        .replyWithError('something awful happened');
+
+      const { compilation, chunk } = this;
+      this.plugin.uploadSourceMap(compilation, chunk, (err) => {
+        expect(err).toExist();
+        expect(err).toInclude({
+          message: 'failed to upload vendor.5190.js.map to Rollbar: something awful happened',
+        });
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Webpack/Next cannot successfully build with the `afterEmit` hook after 4.29.0. Replacing the `afterEmit` hook with `emit` seems to fix the issue. Our Next build no longer throws the error after this change but I'm not 100% sure if it actually works (it seems to!).

See https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/61