### PR TITLE
Handle publicPath with or without trailing slash

### DIFF
--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -80,7 +80,8 @@ class RollbarSourceMapPlugin {
 
   getPublicPath(sourceFile) {
     if (isString(this.publicPath)) {
-      return `${this.publicPath}/${sourceFile}`;
+      const sep = this.publicPath.endsWith('/') ? '' : '/';
+      return `${this.publicPath}${sep}${sourceFile}`;
     }
     return this.publicPath(sourceFile);
   }

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -204,7 +204,7 @@ describe('RollbarSourceMapPlugin', function() {
       this.options = {
         accessToken: 'aaaabbbbccccddddeeeeffff00001111',
         version: 'master-latest-sha',
-        publicPath: 'https://my.cdn.net/assets'
+        publicPath: 'https://my.cdn.net/assets/'
       };
       this.sourceFile = 'vendor.5190.js';
     });
@@ -213,6 +213,20 @@ describe('RollbarSourceMapPlugin', function() {
       const plugin = new RollbarSourceMapPlugin(this.options);
       const result = plugin.getPublicPath(this.sourceFile);
       expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
+    });
+
+    it('should handle \'publicPath\' string without trailing /', function() {
+      this.options.publicPath = 'https://my.cdn.net/assets';
+      const plugin = new RollbarSourceMapPlugin(this.options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.cdn.net/assets/vendor.5190.js');
+    });
+
+    it('should return whatever is returned by publicPath argument when it\'s a function', function () {
+      const options = Object.assign({}, this.options, { publicPath: sourceFile => `https://my.function.proxy.cdn/assets/${sourceFile}` });
+      const plugin = new RollbarSourceMapPlugin(options);
+      const result = plugin.getPublicPath(this.sourceFile);
+      expect(result).toBe('https://my.function.proxy.cdn/assets/vendor.5190.js');
     });
 
     it('should return whatever is returned by publicPath argument when it\'s a function', function () {


### PR DESCRIPTION
# Overview

This resolves #74.

`output.publicPath` in webpack output is generally expected to end in `/`. However, this plugin was expecting no trailing `/` and was always appending `/`, leading to double `/`. This is backwards compatible change handle both cases.