### PR TITLE
Remove expect dependency and use jest expect

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": "airbnb-base",
   "env": {
-    "mocha": true
+    "jest": true
   },
   "parserOptions": {
     "ecmaFeatures": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4406,38 +4406,6 @@
         "is-arrayish": "^0.2.1"
       }
     },
-    "es-abstract": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
-      "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
-      },
-      "dependencies": {
-        "function-bind": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-          "dev": true
-        }
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-      "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
-      }
-    },
     "es6-error": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
@@ -4834,21 +4802,6 @@
             "is-extendable": "^0.1.0"
           }
         }
-      }
-    },
-    "expect": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/expect/-/expect-1.20.2.tgz",
-      "integrity": "sha1-1Fj+TFYAQDa64yMkFqP2Nh8E+WU=",
-      "dev": true,
-      "requires": {
-        "define-properties": "~1.1.2",
-        "has": "^1.0.1",
-        "is-equal": "^1.5.1",
-        "is-regex": "^1.0.3",
-        "object-inspect": "^1.1.0",
-        "object-keys": "^1.0.9",
-        "tmatch": "^2.0.1"
       }
     },
     "extend": {
@@ -6264,15 +6217,6 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
       "dev": true
     },
-    "is-arrow-function": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-arrow-function/-/is-arrow-function-2.0.3.tgz",
-      "integrity": "sha1-Kb4sLY2UUIUri7r7Y1unuNjofsI=",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.0.4"
-      }
-    },
     "is-binary-path": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
@@ -6282,12 +6226,6 @@
       "requires": {
         "binary-extensions": "^1.0.0"
       }
-    },
-    "is-boolean-object": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
-      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
-      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -6303,12 +6241,6 @@
       "requires": {
         "builtin-modules": "^1.0.0"
       }
-    },
-    "is-callable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
-      "dev": true
     },
     "is-ci": {
       "version": "2.0.0",
@@ -6364,25 +6296,6 @@
         }
       }
     },
-    "is-equal": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/is-equal/-/is-equal-1.5.5.tgz",
-      "integrity": "sha1-XoXxlX4FKIMkf+s4aWWju6Ffuz0=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1",
-        "is-arrow-function": "^2.0.3",
-        "is-boolean-object": "^1.0.0",
-        "is-callable": "^1.1.3",
-        "is-date-object": "^1.0.1",
-        "is-generator-function": "^1.0.6",
-        "is-number-object": "^1.0.3",
-        "is-regex": "^1.0.3",
-        "is-string": "^1.0.4",
-        "is-symbol": "^1.0.1",
-        "object.entries": "^1.0.4"
-      }
-    },
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
@@ -6405,12 +6318,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
       "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
-      "dev": true
-    },
-    "is-generator-function": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.7.tgz",
-      "integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
       "dev": true
     },
     "is-glob": {
@@ -6442,12 +6349,6 @@
           }
         }
       }
-    },
-    "is-number-object": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
-      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
-      "dev": true
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -6494,15 +6395,6 @@
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
-    "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.1"
-      }
-    },
     "is-resolvable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
@@ -6513,18 +6405,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
-    },
-    "is-string": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
-      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
-      "dev": true
-    },
-    "is-symbol": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
       "dev": true
     },
     "is-typedarray": {
@@ -8922,12 +8802,6 @@
         }
       }
     },
-    "object-inspect": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
-      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw==",
-      "dev": true
-    },
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
@@ -8961,18 +8835,6 @@
           "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
           "dev": true
         }
-      }
-    },
-    "object.entries": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-      "integrity": "sha1-G/mk3SKI9bM/Opk9JXZh8F0WGl8=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
       }
     },
     "object.getownpropertydescriptors": {
@@ -10628,12 +10490,6 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-      "dev": true
-    },
-    "tmatch": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/tmatch/-/tmatch-2.0.1.tgz",
-      "integrity": "sha1-DFYkbzPzDaG409colauvFmYPOM8=",
       "dev": true
     },
     "tmp": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "eslint": "^4.19.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.9.0",
-    "expect": "^1.20.2",
     "jest": "^24.1.0",
     "nock": "^9.2.3",
     "nyc": "^15.0.0",

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -90,7 +90,7 @@ class RollbarSourceMapPlugin {
     const req = request.post(this.rollbarEndpoint, (err, res, body) => {
       if (!err && res.statusCode === 200) {
         if (!this.silent) {
-          console.info(`Uploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
+          console.info(`\nUploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
         }
         return cb();
       }
@@ -103,8 +103,8 @@ class RollbarSourceMapPlugin {
       try {
         const { message } = JSON.parse(body);
         return cb(new Error(message ? `${errMessage}: ${message}` : errMessage));
-      } catch (parseErr) {
-        return cb(new VError(parseErr, errMessage));
+      } catch (_err) {
+        return cb(new Error(errMessage));
       }
     });
 

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -90,7 +90,8 @@ class RollbarSourceMapPlugin {
     const req = request.post(this.rollbarEndpoint, (err, res, body) => {
       if (!err && res.statusCode === 200) {
         if (!this.silent) {
-          console.info(`\nUploaded ${sourceMap} to Rollbar`); // eslint-disable-line no-console
+          // eslint-disable-next-line no-console
+          console.info(`Uploaded ${sourceMap} to Rollbar`);
         }
         return cb();
       }
@@ -122,6 +123,10 @@ class RollbarSourceMapPlugin {
     const assets = this.getAssets(compilation);
     const upload = this.uploadSourceMap.bind(this, compilation);
 
+    /* istanbul ignore if */
+    if (assets.length > 0) {
+      process.stdout.write('\n');
+    }
     async.each(assets, upload, (err, results) => {
       if (err) {
         return cb(err);

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,60 +1,57 @@
-import expect from 'expect';
 import { ROLLBAR_REQ_FIELDS } from '../src/constants';
 import * as helpers from '../src/helpers';
 
-describe('helpers', function () {
-  describe('handleError', function () {
-    it('returns an array of length 1 given a single error', function () {
+describe('helpers', () => {
+  describe('handleError', () => {
+    it('returns an array of length 1 given a single error', () => {
       const result = helpers.handleError(new Error('required field missing'));
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toEqual(1);
     });
 
-    it('returns an array of length 2 given an array of length 2', function () {
+    it('returns an array of length 2 given an array of length 2', () => {
       const result = helpers.handleError([
         new Error('required field missing'),
         new Error('request failed')
       ]);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toEqual(2);
     });
 
-    it('prefixes message of single error', function () {
+    it('prefixes message of single error', () => {
       const result = helpers.handleError(new Error('required field missing'), 'Plugin');
       expect(result.length).toEqual(1);
-      expect(result[0]).toInclude({ message: 'Plugin: required field missing' });
+      expect(result[0].message).toBe('Plugin: required field missing');
     });
 
-    it('prefixes message of an array of errors', function () {
+    it('prefixes message of an array of errors', () => {
       const result = helpers.handleError([
         new Error('required field missing'),
         new Error('request failed')
       ], 'Plugin');
       expect(result.length).toEqual(2);
-      expect(result[0]).toInclude({ message: 'Plugin: required field missing' });
+      expect(result[0].message).toBe('Plugin: required field missing');
     });
 
-    it('defaults prefix to "RollbarSourceMapPlugin"', function () {
+    it('defaults prefix to "RollbarSourceMapPlugin"', () => {
       const result = helpers.handleError(new Error('required field missing'));
       expect(result.length).toEqual(1);
-      expect(result[0]).toInclude({
-        message: 'RollbarSourceMapPlugin: required field missing'
-      });
+      expect(result[0].message).toBe('RollbarSourceMapPlugin: required field missing');
     });
 
-    it('handles null', function () {
+    it('handles null', () => {
       const result = helpers.handleError(null);
       expect(result).toEqual([]);
     });
 
-    it('handles empty []', function () {
+    it('handles empty []', () => {
       const result = helpers.handleError([]);
       expect(result).toEqual([]);
     });
   });
 
-  describe('validateOptions', function () {
-    it('returns null if all required options are supplied', function () {
+  describe('validateOptions', () => {
+    it('returns null if all required options are supplied', () => {
       const options = {
         accessToken: 'aaabbbccc000111',
         version: 'latest',
@@ -64,75 +61,75 @@ describe('helpers', function () {
       expect(result).toBe(null); // eslint-disable-line no-unused-expressions
     });
 
-    it('returns an error if accessToken is not supplied', function () {
+    it('returns an error if accessToken is not supplied', () => {
       const options = {
         version: 'latest',
         publicPath: 'https://my.cdn.net/assets'
       };
       const result = helpers.validateOptions(options);
-      expect(result).toBeA('array');
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(1);
-      expect(result[0]).toBeA(Error)
-        .toInclude({ message: 'required field, \'accessToken\', is missing.' });
+      expect(result[0]).toBeInstanceOf(Error);
+      expect(result[0].message).toBe('required field, \'accessToken\', is missing.');
     });
 
-    it('returns an error if version is not supplied', function () {
+    it('returns an error if version is not supplied', () => {
       const options = {
         accessToken: 'aaabbbccc000111',
         publicPath: 'https://my.cdn.net/assets'
       };
       const result = helpers.validateOptions(options);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(1);
-      expect(result[0]).toBeA(Error)
-        .toInclude({ message: 'required field, \'version\', is missing.' });
+      expect(result[0]).toBeInstanceOf(Error);
+      expect(result[0].message).toBe('required field, \'version\', is missing.');
     });
 
-    it('returns an error if publicPath is not supplied', function () {
+    it('returns an error if publicPath is not supplied', () => {
       const options = {
         accessToken: 'aaabbbccc000111',
         version: 'latest'
       };
       const result = helpers.validateOptions(options);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(1);
-      expect(result[0]).toBeA(Error)
-        .toInclude({ message: 'required field, \'publicPath\', is missing.' });
+      expect(result[0]).toBeInstanceOf(Error);
+      expect(result[0].message).toBe('required field, \'publicPath\', is missing.');
     });
 
-    it('handles multiple missing required options', function () {
+    it('handles multiple missing required options', () => {
       const options = {};
       const result = helpers.validateOptions(options);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(ROLLBAR_REQ_FIELDS.length);
     });
 
-    it('handles null for options', function () {
+    it('handles null for options', () => {
       const result = helpers.validateOptions(null);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(ROLLBAR_REQ_FIELDS.length);
     });
 
-    it('handles no options passed', function () {
+    it('handles no options passed', () => {
       const result = helpers.validateOptions();
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(ROLLBAR_REQ_FIELDS.length);
     });
 
-    it('returns an error if publicPath is not a string nor a function', function () {
+    it('returns an error if publicPath is not a string nor a function', () => {
       const options = {
         accessToken: 'aaabbbccc000111',
         version: 'latest',
         publicPath: 3
       };
       const result = helpers.validateOptions(options);
-      expect(result).toBeA(Array);
+      expect(result).toBeInstanceOf(Array);
       expect(result.length).toBe(1);
-      expect(result[0]).toBeA(TypeError)
-        .toInclude({ message: 'invalid type. \'publicPath\' expected to be string or function.' });
+      expect(result[0]).toBeInstanceOf(TypeError);
+      expect(result[0].message).toBe('invalid type. \'publicPath\' expected to be string or function.');
     });
 
-    it('returns null if all required arguments are provided and accept a function as the publicPath argument', function () {
+    it('returns null if all required arguments are provided and accept a function as the publicPath argument', () => {
       const options = {
         accessToken: 'aaabbbccc000111',
         version: 'latest',


### PR DESCRIPTION
When migrating to Jest in #62, usage of https://github.com/mjackson/expect was left in order to keep the PR small. In this PR we remove expect dependency and use Jest's expect. Also some minor style cleanup. 