### PR TITLE
Drop support for Webpack v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "request": "^2.88.0",
     "verror": "^1.6.1"
   },
+  "peerDependencies": {
+    "webpack": "^4.0.0"
+  },
   "lint-staged": {
     "*.js": [
       "eslint --cache --fix"

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -49,14 +49,7 @@ class RollbarSourceMapPlugin {
   }
 
   apply(compiler) {
-    if (compiler.hooks) {
-      compiler.hooks.afterEmit.tapAsync(
-        'after-emit',
-        this.afterEmit.bind(this)
-      );
-    } else {
-      compiler.plugin('after-emit', this.afterEmit.bind(this));
-    }
+    compiler.hooks.afterEmit.tapAsync('after-emit', this.afterEmit.bind(this));
   }
 
   getAssets(compilation) {

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -96,16 +96,6 @@ describe('RollbarSourceMapPlugin', () => {
         expect.any(Function)
       );
     });
-
-    it('plugs into `after-emit" when "hooks" is undefined', () => {
-      delete compiler.hooks;
-      plugin.apply(compiler);
-      expect(compiler.plugin).toHaveBeenCalledTimes(1);
-      expect(compiler.plugin).toHaveBeenCalledWith(
-        'after-emit',
-        expect.any(Function)
-      );
-    });
   });
 
   describe('afterEmit', () => {


### PR DESCRIPTION
# Overview

Removes backward compatibility with deprecated `Tapable.plugin` interface. Now requires `Tabable.hooks` interface and thus in order to use the plugin you will need to be running Webpack 4.

Dropping `Tapable.plugin` support will allow for some code cleanup and pave the way for more easily resolving issues such as #45, #68, #183 

This is a breaking change.
