### PR TITLE
Webpack 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "verror": "^1.6.1"
   },
   "peerDependencies": {
-    "webpack": "^4.0.0"
+    "webpack": ">= 4"
   },
   "lint-staged": {
     "*.js": [

--- a/src/RollbarSourceMapPlugin.js
+++ b/src/RollbarSourceMapPlugin.js
@@ -75,7 +75,13 @@ class RollbarSourceMapPlugin {
       }
 
       const sourceFile = chunk.files.find(file => /\.js$/.test(file));
-      const sourceMap = chunk.files.find(file => /\.js\.map$/.test(file));
+
+      // webpack 5 stores source maps in `chunk.auxiliaryFiles` while webpack 4
+      // stores them in `chunk.files`. This allows both webpack versions to work
+      // with this plugin.
+      const sourceMap = (chunk.auxiliaryFiles || chunk.files).find(file =>
+        /\.js\.map$/.test(file)
+      );
 
       if (!sourceFile || !sourceMap) {
         return result;

--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -361,6 +361,22 @@ describe('RollbarSourceMapPlugin', () => {
         }
       ]);
     });
+
+    it('works with webpack 5', () => {
+      chunks = [
+        {
+          id: 0,
+          names: ['vendor'],
+          files: ['vendor.5190.js'],
+          auxiliaryFiles: ['vendor.5190.js.map']
+        }
+      ];
+
+      const assets = plugin.getAssets(compilation);
+      expect(assets).toEqual([
+        { sourceFile: 'vendor.5190.js', sourceMap: 'vendor.5190.js.map' }
+      ]);
+    });
   });
 
   describe('uploadSourceMaps', () => {


### PR DESCRIPTION
webpack 5 stores source maps in `chunk.auxiliaryFiles` instead of `chunk.files`.  This PR updates the plugin to support both webapck 4 and 5 by first checking if `auxiliaryFiles` for webpack 5 and if not it will fallback to `files` for webpack 4.

I also updated the peer dependency range to allow rollbar 4+ to fix the warning.