### PR TITLE
Add BabelEsmPlugin support

### DIFF
--- a/test/RollbarSourceMapPlugin.test.js
+++ b/test/RollbarSourceMapPlugin.test.js
@@ -302,6 +302,26 @@ describe('RollbarSourceMapPlugin', () => {
       ]);
     });
 
+    it('handles multiple source files', () => {
+      chunks = [
+        {
+          id: 1,
+          names: ['app'],
+          files: [
+            'app.81c1.js',
+            'app.81c1.js.map',
+            'app.81c1.esm.js',
+            'app.81c1.esm.js.map'
+          ]
+        }
+      ];
+      const assets = plugin.getAssets(compilation);
+      expect(assets).toEqual([
+        { sourceFile: 'app.81c1.js', sourceMap: 'app.81c1.js.map' },
+        { sourceFile: 'app.81c1.esm.js', sourceMap: 'app.81c1.esm.js.map' }
+      ]);
+    });
+
     it('includes unnamed chunks when includeChunks is not specified', () => {
       chunks = [
         {


### PR DESCRIPTION
 [babel-esm-plugin ](https://github.com/prateekbh/babel-esm-plugin/) generates ESM counterparts for bundles and chunks. 

It appends `esm.js` files to the chunk's `files` property, like so:

```
[
      'storage.io.chunk.e6fc7.js',
      'storage.io.chunk.e6fc7.js.map',
      'storage.io.chunk.e6fc7.esm.js',
      'storage.io.chunk.e6fc7.esm.js.map'
];
```

`rollbar-sourcemap-webpack-plugin` uses `Array.find` in the reducer that generates the `sourceFile, sourceMap` entries. This leads to skipping the ESM sourcemaps from being uploaded because find only returns first occurrence of a match.

This PR addresses that by switching to `Array.filter`.