### PR TITLE
Add option to retry Rollbar upload request in case it fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ A string defining the Rollbar API endpoint to upload the sourcemaps to. It can b
 
 Set to true to encode the filename. NextJS will reference the encode the URL when referencing the minified script which must match exactly with the minified file URL uploaded to Rollbar.
 
+### `retry: number` **(default: `null`)**
+
+The amount of retries that will be performed to upload the sourcemap to Rollbar in case the upload fails.
+
 ## Webpack Sourcemap Configuration
 
 The [`output.devtool`](https://webpack.js.org/configuration/devtool/) field in webpack configuration controls how sourcemaps are generated.


### PR DESCRIPTION
As some other users of this plugin have [mentioned](https://github.com/thredup/rollbar-sourcemap-webpack-plugin/issues/45), the rollbar sourcemap upload seems to sporadically fail due to unkonwn reasons, causing a lot of issues to users who have added this plugin to their build pipeline.

For that reason, I'm adding a `retry` option to this plugin, if it's not passed, everything still works the same, if it's passed, then in case something wrong happens with the rollbar upload, the plugin will automatically retry to upload the file an X amount of times before really failing the process. The usage is pretty straightforward, a new option was added called `retry`

```js
new RollbarSourceMapPlugin({
    accessToken: 'aaaabbbbccccddddeeeeffff00001111',
    version: 'version_string_here',
    publicPath: PUBLIC_PATH,
    retry: 4, // retries 4 times 😂 
  })
```

Tests were added, and the README is already updated too 🤘 