### PR TITLE
Remove watch dev dependency

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,11 +23,6 @@ npm install
 npm test
 ```
 
-```bash
-# run tests in watch mode for faster feedback
-npm run test:watch
-```
-
 ### Style & Linting
 
 The codebase adheres to the [Airbnb Styleguide](https://github.com/airbnb/javascript)
@@ -60,8 +55,7 @@ The coverage report will be displayed in the terminal after tests run.
 
 Before you submit a pull request from your forked repo, check that it meets these guidelines:
 
-1. If the pull request fixes a bug, it should include tests that fail without the changes, and pass
-with them.
+1. If the pull request fixes a bug, it should include tests that fail without the changes, and pass with them.
 1. Please update README.md accordingly, if relevant, as part of the same PR.
 1. Please rebase and resolve all conflicts before submitting.
 
@@ -87,3 +81,4 @@ npm version minor
 
 # publish a incompatible API change
 npm version major
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -6490,15 +6490,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
-      "dev": true,
-      "requires": {
-        "merge": "^1.1.3"
-      }
-    },
     "execa": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -9936,12 +9927,6 @@
         "object-visit": "^1.0.0"
       }
     },
-    "merge": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
-      "dev": true
-    },
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -12011,24 +11996,6 @@
       "dev": true,
       "requires": {
         "makeerror": "1.0.x"
-      }
-    },
-    "watch": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/watch/-/watch-1.0.2.tgz",
-      "integrity": "sha1-NApxe952Vyb6CqB9ch4BR6VR3ww=",
-      "dev": true,
-      "requires": {
-        "exec-sh": "^0.2.0",
-        "minimist": "^1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-          "dev": true
-        }
       }
     },
     "webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
     "lint:staged": "lint-staged",
     "prebuild": "npm run -s clean",
     "build": "babel src -d dist",
-    "build:watch": "watch 'npm run build' ./src",
     "test": "cross-env NODE_ENV=test jest --coverage",
-    "test:watch": "npm test -- -w",
     "changelog": "npm run changelog:generate && npm run changelog:add",
     "changelog:add": "git add CHANGELOG.md",
     "changelog:generate": "github_changelog_generator --user thredup --project rollbar-sourcemap-webpack-plugin --future-release $npm_package_version",
@@ -58,8 +56,7 @@
     "lint-staged": "^11.0.0",
     "nock": "^13.0.5",
     "prettier": "^2.1.2",
-    "rimraf": "^3.0.2",
-    "watch": "^1.0.1"
+    "rimraf": "^3.0.2"
   },
   "dependencies": {
     "form-data": "^4.0.0",


### PR DESCRIPTION
# Overview

Removes watch dev dep to resolve high security vulnerability. Removes `test:watch` and `build:watch` npm scripts. The watch dep is not needed as babel and jest have watchers built in.